### PR TITLE
docs: show every model in the navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,12 +72,86 @@ nav:
       - RTX 5090 TTS benchmarks: guides/rtx-5090-tts-benchmarks.md
   - Notebooks: guides/notebook.md
   - Models:
-      - Model guides: models/providers/index.md
-      - TTS model catalog: models/index.md
-      - TTS capabilities: models/tts-capabilities.md
-      - ASR and VAD support: models/asr-vad-support.md
-      - TTS training support: models/training-support.md
-      - XTTS v2 native DVAE: models/xtts2.md
+      - Overview: models/providers/index.md
+      # BEGIN GENERATED MODEL GUIDE NAVIGATION
+      - Text to speech:
+          - "bark": models/providers/bark.md
+          - "chatterbox": models/providers/chatterbox.md
+          - "conversationtts": models/providers/conversationtts.md
+          - "cosyvoice": models/providers/cosyvoice.md
+          - "csm": models/providers/csm.md
+          - "dia": models/providers/dia.md
+          - "echo": models/providers/echo.md
+          - "f5tts": models/providers/f5tts.md
+          - "fishtts": models/providers/fishtts.md
+          - "gptsovits": models/providers/gptsovits.md
+          - "higgstts": models/providers/higgstts.md
+          - "inflecttts": models/providers/inflecttts.md
+          - "irodoritts": models/providers/irodoritts.md
+          - "kokoro": models/providers/kokoro.md
+          - "llasa": models/providers/llasa.md
+          - "melotts": models/providers/melotts.md
+          - "mosstts": models/providers/mosstts.md
+          - "neutts": models/providers/neutts.md
+          - "omnivoice": models/providers/omnivoice.md
+          - "openvoice": models/providers/openvoice.md
+          - "orpheustts": models/providers/orpheustts.md
+          - "outetts": models/providers/outetts.md
+          - "parlertts": models/providers/parlertts.md
+          - "qwen3tts": models/providers/qwen3tts.md
+          - "speecht5": models/providers/speecht5.md
+          - "styletts2": models/providers/styletts2.md
+          - "supertonic": models/providers/supertonic.md
+          - "vibevoice": models/providers/vibevoice.md
+          - "vits": models/providers/vits.md
+          - "voxcpm": models/providers/voxcpm.md
+          - "vui": models/providers/vui.md
+          - "xtts": models/providers/xtts.md
+          - "zonos": models/providers/zonos.md
+          - "zonos2": models/providers/zonos2.md
+      - Automatic speech recognition:
+          - "asr_cohere": models/providers/asr_cohere.md
+          - "asr_espnet": models/providers/asr_espnet.md
+          - "asr_faster_whisper": models/providers/asr_faster_whisper.md
+          - "asr_funasr": models/providers/asr_funasr.md
+          - "asr_granite_speech": models/providers/asr_granite_speech.md
+          - "asr_hubert": models/providers/asr_hubert.md
+          - "asr_medasr": models/providers/asr_medasr.md
+          - "asr_moonshine": models/providers/asr_moonshine.md
+          - "asr_nemo": models/providers/asr_nemo.md
+          - "asr_nemotron": models/providers/asr_nemotron.md
+          - "asr_openai_whisper": models/providers/asr_openai_whisper.md
+          - "asr_parakeet_tdt": models/providers/asr_parakeet_tdt.md
+          - "asr_qwen3": models/providers/asr_qwen3.md
+          - "asr_seamless_m4t_v2": models/providers/asr_seamless_m4t_v2.md
+          - "asr_speechbrain": models/providers/asr_speechbrain.md
+          - "asr_tiron": models/providers/asr_tiron.md
+          - "asr_transformers": models/providers/asr_transformers.md
+          - "asr_vibevoice": models/providers/asr_vibevoice.md
+          - "asr_wav2vec2": models/providers/asr_wav2vec2.md
+          - "asr_wavlm": models/providers/asr_wavlm.md
+          - "asr_wenet": models/providers/asr_wenet.md
+          - "asr_whisper": models/providers/asr_whisper.md
+          - "asr_whisperx": models/providers/asr_whisperx.md
+      - Voice activity detection:
+          - "vad_auditok": models/providers/vad_auditok.md
+          - "vad_funasr": models/providers/vad_funasr.md
+          - "vad_nemo": models/providers/vad_nemo.md
+          - "vad_pyannote": models/providers/vad_pyannote.md
+          - "vad_pyannote_brouhaha": models/providers/vad_pyannote_brouhaha.md
+          - "vad_pyannote_segmentation": models/providers/vad_pyannote_segmentation.md
+          - "vad_sherpa_onnx": models/providers/vad_sherpa_onnx.md
+          - "vad_silero": models/providers/vad_silero.md
+          - "vad_speechbrain": models/providers/vad_speechbrain.md
+          - "vad_transformers": models/providers/vad_transformers.md
+          - "vad_webrtc": models/providers/vad_webrtc.md
+      # END GENERATED MODEL GUIDE NAVIGATION
+      - Catalogs and support:
+          - TTS model catalog: models/index.md
+          - TTS capabilities: models/tts-capabilities.md
+          - ASR and VAD support: models/asr-vad-support.md
+          - TTS training support: models/training-support.md
+          - XTTS v2 native DVAE: models/xtts2.md
   - Architecture:
       - Library architecture: concepts/architecture.md
       - Trainer architecture: concepts/trainer.md

--- a/scripts/generate_model_pages.py
+++ b/scripts/generate_model_pages.py
@@ -23,9 +23,12 @@ from generate_model_notebooks import (  # noqa: E402
 from voicehub import list_model_specs  # noqa: E402
 
 MODEL_PAGE_DIR = REPOSITORY_ROOT / "docs" / "models" / "providers"
+SITE_CONFIG_PATH = REPOSITORY_ROOT / "mkdocs.yml"
 GENERATOR_PATH = "scripts/generate_model_pages.py"
 COLAB_ROOT = ("https://colab.research.google.com/github/kadirnar/voicehub/"
               "blob/main/notebooks/models")
+NAVIGATION_START = "      # BEGIN GENERATED MODEL GUIDE NAVIGATION"
+NAVIGATION_END = "      # END GENERATED MODEL GUIDE NAVIGATION"
 
 
 def _value(value) -> str:
@@ -481,11 +484,37 @@ def render_index(specs) -> str:
     return "\n".join(lines)
 
 
+def render_navigation(specs) -> str:
+    """Render the task-grouped model links shown in the site sidebar."""
+    lines = [NAVIGATION_START]
+    for task in TASK_ORDER:
+        task_specs = sorted(
+            (spec for spec in specs if spec.task.value == task),
+            key=lambda spec: spec.model_type,
+        )
+        lines.append(f"      - {TASK_LABELS[task]}:")
+        lines.extend(
+            f'          - "{spec.model_type}": models/providers/{spec.model_type}.md' for spec in task_specs)
+    lines.append(NAVIGATION_END)
+    return "\n".join(lines)
+
+
+def render_site_config(specs) -> str:
+    """Replace only the generated model-navigation block in ``mkdocs.yml``."""
+    source = SITE_CONFIG_PATH.read_text(encoding="utf-8")
+    if source.count(NAVIGATION_START) != 1 or source.count(NAVIGATION_END) != 1:
+        raise RuntimeError("mkdocs.yml must contain exactly one generated model navigation block")
+    prefix, remainder = source.split(NAVIGATION_START, 1)
+    _, suffix = remainder.split(NAVIGATION_END, 1)
+    return f"{prefix}{render_navigation(specs)}{suffix}"
+
+
 def generated_files() -> dict[Path, str]:
     """Return every expected generated path and its contents."""
     specs = tuple(list_model_specs(task=None))
     files = {MODEL_PAGE_DIR / f"{spec.model_type}.md": render_page(spec) for spec in specs}
     files[MODEL_PAGE_DIR / "index.md"] = render_index(specs)
+    files[SITE_CONFIG_PATH] = render_site_config(specs)
     return files
 
 
@@ -516,7 +545,8 @@ def main() -> int:
             for path in stale:
                 print(f"stale: {path.relative_to(REPOSITORY_ROOT)}", file=sys.stderr)
             return 1
-        print(f"OK: {len(files) - 1} model pages are current")
+        page_count = sum(path.parent == MODEL_PAGE_DIR and path.name != "index.md" for path in files)
+        print(f"OK: {page_count} model pages and navigation are current")
         return 0
 
     MODEL_PAGE_DIR.mkdir(parents=True, exist_ok=True)
@@ -529,7 +559,8 @@ def main() -> int:
         if not path.is_file() or path.read_text(encoding="utf-8") != content:
             path.write_text(content, encoding="utf-8", newline="\n")
             print(f"wrote: {path.relative_to(REPOSITORY_ROOT)}")
-    print(f"OK: {len(files) - 1} model pages")
+    page_count = sum(path.parent == MODEL_PAGE_DIR and path.name != "index.md" for path in files)
+    print(f"OK: {page_count} model pages and navigation")
     return 0
 
 

--- a/tests/test_documentation_site.py
+++ b/tests/test_documentation_site.py
@@ -250,6 +250,7 @@ class DocumentationSiteTests(unittest.TestCase):
         self.assertTrue(expected_paths)
 
         index = MODEL_PAGE_INDEX_PATH.read_text(encoding="utf-8")
+        config = SITE_CONFIG_PATH.read_text(encoding="utf-8")
         for path, spec in expected_paths.items():
             with self.subTest(model_type=spec.model_type):
                 source = path.read_text(encoding="utf-8")
@@ -261,6 +262,11 @@ class DocumentationSiteTests(unittest.TestCase):
                 self.assertIn(spec.task.value.replace("-", " "), source.lower())
                 self.assertIn(spec.training.support.value, source)
                 self.assertIn(f"[`{spec.model_type}`]({path.name})", index)
+                self.assertEqual(
+                    config.count(f"models/providers/{path.name}"),
+                    1,
+                    f"{spec.model_type} should appear once in the Models sidebar",
+                )
                 if spec.default_model_path:
                     self.assertIn(spec.default_model_path, source)
                 if re.fullmatch(r"[^/\s]+/[^/\s]+", spec.default_model_path):
@@ -281,6 +287,9 @@ class DocumentationSiteTests(unittest.TestCase):
         generator = runpy.run_path(str(MODEL_PAGE_GENERATOR_PATH))
         generated_files = generator["generated_files"]()
         self.assertEqual(generator["check_generated_files"](generated_files), ())
+        self.assertIn("- Text to speech:", config)
+        self.assertIn("- Automatic speech recognition:", config)
+        self.assertIn("- Voice activity detection:", config)
 
     def test_notebook_code_cells_compile_and_execute_in_smoke_mode(self):
         namespaces = {}


### PR DESCRIPTION
## Summary

- list all 68 generated model guides in the Models sidebar
- group model links by text-to-speech, speech recognition, and voice activity detection
- generate and validate the navigation from the model registry so future models are added automatically

## Validation

- `.venv/bin/python scripts/generate_model_pages.py --check`
- `.venv/bin/python -m pytest -q tests/test_documentation_site.py` (`20 passed, 1001 subtests passed`)
- `.venv/bin/mkdocs build --strict --clean`
- `.venv/bin/pre-commit run --files mkdocs.yml scripts/generate_model_pages.py tests/test_documentation_site.py`