### PR TITLE
feat: harden 0.3 release readiness

### DIFF
--- a/.github/workflows/package_testing.yml
+++ b/.github/workflows/package_testing.yml
@@ -31,6 +31,12 @@ jobs:
           python -m pip install --upgrade pip build "nbformat>=5.10" numpy pytest soundfile uv
           python -m build
 
+      - name: Verify source, documentation, and benchmark version alignment
+        run: python scripts/check_release.py --dist-dir dist
+
+      - name: Validate wheel, sdist, editable, provenance, and license data
+        run: python scripts/check_distribution.py
+
       - name: Verify the dependency-free package surface
         run: |
           python -m pip install --force-reinstall --no-deps dist/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,145 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag, for example v0.3.0
+        required: true
+        type: string
+      confirm_publish:
+        description: Publish the verified artifacts after the protected environment approval
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  tagged-cross-platform-tests:
+    name: Tagged tests (${{ matrix.operating-system }} / Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout the requested tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install the complete test environment
+        run: |
+          python -m pip install --upgrade pip uv
+          uv pip install --system --torch-backend cpu -e ".[test]"
+
+      - name: Run the complete test suite
+        run: python -m pytest -q
+
+  verify-and-build:
+    name: Verify and build tagged source
+    needs: tagged-cross-platform-tests
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
+
+    steps:
+      - name: Checkout the requested tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install the release environment
+        run: |
+          python -m pip install --upgrade pip uv
+          uv pip install --system --torch-backend cpu -e ".[test,training,docs]"
+
+      - name: Verify source, tag, benchmark, and PyPI candidate state
+        run: >-
+          python scripts/check_release.py
+          --tag "$RELEASE_TAG"
+          --require-tag-at-head
+          --pypi-policy candidate
+
+      - name: Run the complete test suite
+        run: python -m pytest -q
+
+      - name: Run repository-wide formatting and lint checks
+        run: pre-commit run --all-files
+
+      - name: Build strict documentation
+        run: mkdocs build --strict --clean --site-dir site
+
+      - name: Validate wheel, sdist, and editable installations
+        run: python scripts/check_distribution.py
+
+      - name: Build the publication artifacts
+        run: python -m build --outdir release-dist
+
+      - name: Verify publication artifact metadata and size
+        run: >-
+          python scripts/check_release.py
+          --tag "$RELEASE_TAG"
+          --require-tag-at-head
+          --dist-dir release-dist
+
+      - name: Record publication artifact hashes
+        run: sha256sum release-dist/*
+
+      - name: Upload the verified publication artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: voicehub-${{ inputs.tag }}-distributions
+          path: release-dist/*
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish verified artifacts to PyPI
+    if: ${{ inputs.confirm_publish }}
+    needs:
+      - tagged-cross-platform-tests
+      - verify-and-build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/voicehub
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download the verified publication artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: voicehub-${{ inputs.tag }}-distributions
+          path: dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
+        with:
+          packages-dir: dist/

--- a/GOAL.md
+++ b/GOAL.md
@@ -1,0 +1,45 @@
+# VoiceHub 0.3 Release Goal
+
+Turn VoiceHub 0.3.x into a trustworthy, publishable release candidate for a
+unified open-speech runtime.
+
+## Intended outcome
+
+Prepare a release that users can install in a clean environment, inspect
+through one registry, run with representative real checkpoints, and evaluate
+through traceable evidence. Harden the existing TTS, ASR, and VAD surface
+instead of expanding the provider catalogue.
+
+## Constraints
+
+- Do not add another model or provider until every release gate is complete.
+- Preserve the public API, lazy loading, normalized outputs, safe checkpoint
+  boundaries, and license boundaries. If a breaking change becomes necessary,
+  document it and request a user decision first.
+- Do not publish unmeasured speed or quality claims. Never report an unavailable
+  checkpoint, GPU path, or unexecuted workflow as successful.
+- Preserve existing user changes, especially the untracked `uv.lock` file.
+- Do not push, merge, create a GitHub release, or publish to PyPI without
+  explicit user approval.
+
+## Completion criteria
+
+1. The source version, package metadata, README, documentation, and roadmap
+   describe the same VoiceHub 0.3.x product contract. Completed historical
+   roadmap items are removed or updated.
+1. The wheel and source distribution install in clean environments. Import,
+   registry, package-data, provenance, and license contracts are verified for
+   every registered runtime.
+1. Python 3.10 through 3.12 CI passes on Linux, macOS, and Windows. Every locally
+   applicable gate passes: the full test suite, repository-wide pre-commit,
+   strict MkDocs, and `scripts/check_distribution.py`.
+1. TTS, ASR, and VAD have a layered verification matrix: CPU-safe contract
+   tests cover every provider; representative priority providers have real-
+   checkpoint end-to-end smoke or benchmark evidence; inaccessible GPU or
+   checkpoint gates are explicitly recorded as pending.
+1. The repository contains a reproducible release checklist and a manually
+   approved PyPI Trusted Publishing workflow. Automated checks detect version
+   drift between PyPI, GitHub, package artifacts, and documentation.
+1. A release-candidate report summarizes passed gates, remaining risks,
+   benchmark evidence, and the final publication approval required from the
+   user.

--- a/LOOP.md
+++ b/LOOP.md
@@ -1,0 +1,30 @@
+# VoiceHub Release-Readiness Loop
+
+Run the following loop for each release-readiness iteration:
+
+1. Read `GOAL.md`, new user messages, `git status`, and the current evidence,
+   including tests, CI, documentation, benchmarks, and release reports. Preserve
+   user changes, especially the untracked `uv.lock` file.
+1. Re-rank the remaining gaps against the completion criteria. Select the
+   highest-impact bounded task. Do not add a model or provider while a release
+   gate remains open.
+1. When current external information is required, verify it with primary or
+   authoritative sources. Do not add unsupported compatibility, performance,
+   quality, or availability claims.
+1. Complete the selected task end to end with the smallest coherent code or
+   documentation change, a regression test, and supporting evidence. Run a
+   focused test first, followed by repository checks proportional to the risk.
+   Never count an unexecuted, failed, hardware-limited, or inaccessible path as
+   passed; record the exact pending gate instead.
+1. If another change overlaps the same files, do not overwrite it. Move to the
+   next non-conflicting release gap when meaningful progress is possible;
+   otherwise, report the precise blocker.
+1. At the end of each iteration, report the change, checks executed, results,
+   and the next release gap. Do not create cosmetic changes merely to keep the
+   loop active.
+1. Do not commit, push, merge, create or close GitHub issues or releases, or
+   publish to PyPI. Stop and request a user decision when work requires a
+   breaking API choice, secret, paid resource, or external state change.
+1. When every completion criterion is proven, make no further changes. Present
+   the release-candidate report, mark the goal complete, disable the recurring
+   loop, and wait for explicit publication approval.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ VoiceHub provides lazy model loading, normalized outputs, shared optimization
 controls, and a common trainer. Model weights are downloaded only when a
 selected model is loaded.
 
+The 0.3 release line is an evidence-first unified open-speech runtime: its
+existing TTS, ASR, and VAD integrations are being hardened as one installable
+surface before the built-in provider catalogue grows again.
+
 ## Install
 
 VoiceHub supports Python 3.10 through 3.12.

--- a/benchmarks/tts_optimization_rtx4090_2026-07-31.json
+++ b/benchmarks/tts_optimization_rtx4090_2026-07-31.json
@@ -70,7 +70,7 @@
       "name": "tts_vui_rtx4090_rejected_2026-07-31.json",
       "repository_path": "benchmarks/tts_vui_rtx4090_rejected_2026-07-31.json",
       "retention": "checked-in",
-      "sha256": "a2fe983f08fcb367366ab3cac302d7a385f7b366269bd1975d15567025ee191e"
+      "sha256": "1d93b7d475da70ed8e05eda7a2369ed65227dc1c79f46592742c79d39f9a7b79"
     },
     {
       "name": "tts_optimization_rtx4090_raw_evidence_2026-07-31.json",

--- a/benchmarks/tts_vui_rtx4090_rejected_2026-07-31.json
+++ b/benchmarks/tts_vui_rtx4090_rejected_2026-07-31.json
@@ -1,6 +1,7 @@
 {
   "benchmark": "voicehub-vui-inference-compile-quality-rejection",
   "date": "2026-07-31",
+  "voicehub_version": "0.3.0",
   "status": "rejected",
   "model_type": "vui",
   "checkpoint": "vui-abraham-100m.pt",

--- a/docs/project/release-readiness.md
+++ b/docs/project/release-readiness.md
@@ -1,0 +1,133 @@
+---
+description: Release checklist, verification matrix, and current candidate report for VoiceHub 0.3.
+release: 0.3.0
+---
+
+# VoiceHub 0.3 release readiness
+
+This is the authoritative release-candidate checklist for VoiceHub 0.3.0.
+It separates locally reproducible checks, cross-platform CI, real-checkpoint
+evidence, and maintainer-controlled publication. A pending hardware or external
+gate is never counted as a pass.
+
+## Candidate report
+
+Updated 2026-08-01. The source version is 0.3.0. PyPI still serves 0.1.6, so
+installing `voicehub` from PyPI does not yet provide the current repository
+contract.
+
+| Gate | Current evidence | Status |
+| --- | --- | --- |
+| Source, docs, benchmark, and PyPI candidate alignment | Local check identified 0.3.0 as a new candidate over PyPI 0.1.6 | Passed |
+| Full CPU-safe suite | Clean macOS runs on Python 3.10, 3.11, and 3.12 each reported 2,343 passed, 25 skipped, 2,593 subtests, and 35 warnings | Passed locally across supported Python versions |
+| Formatting and lint | Repository-wide pre-commit completed after a dedicated 28-file mechanical normalization; a normalized AST audit found no behavior-tree changes | Passed |
+| Documentation | Strict multilingual build completed locally | Passed |
+| Wheel, sdist, and editable installs | All three clean probes reported 68 models, 81 pinned/license-bearing source manifests, 193 installed provenance/legal files, required data present, zero dependency violations, and no eager PyTorch import | Passed |
+| Python 3.10–3.12 on Linux, macOS, and Windows | The committed baseline `03f6884` passed all nine jobs in [CI run 30687784383](https://github.com/kadirnar/voicehub/actions/runs/30687784383); CI and the protected release workflow both define the full 3×3 matrix | Baseline passed; candidate execution pending |
+| Released-checkpoint TTS, ASR, and VAD evidence | Dated RTX 4090 JSON and guide; see matrix below | Passed for the listed representatives |
+| Tokenless publication workflow | Source contract test verifies separate build/publish jobs, protected environment, and job-scoped OIDC | Passed locally; tagged run pending |
+| Protected `pypi` environment and PyPI publisher | GitHub's environment inventory currently contains only `github-pages`; PyPI publisher settings require maintainer access | Pending maintainer configuration |
+| Git tag, GitHub release, and PyPI publication | No local/remote `v0.3.0` tag or matching GitHub release exists; publication requires explicit maintainer approval | Pending |
+
+## Layered verification matrix
+
+Contract coverage and checkpoint coverage answer different questions and stay
+separate in release reports.
+
+| Layer | Scope | Evidence | Interpretation |
+| --- | --- | --- | --- |
+| Registry and lazy construction | All 34 TTS, 23 ASR, and 11 VAD integrations | Full pytest suite plus the TTS and ASR/VAD registry audits | Proves discovery, configuration, lazy allocation, and normalized contract behavior; it does not prove every public weight file |
+| Native graph and checkpoint shape | Every registered family | Model-specific CPU/meta tests and immutable inventory tests | Proves the implemented graph and declared checkpoint namespace under deterministic fixtures |
+| Package surface | Every registered runtime | `scripts/check_distribution.py` and Package CI | Proves wheel, sdist, editable install, package data, import coverage, and declared dependencies |
+| TTS real checkpoint | `vits` with `facebook/mms-tts-eng@c71de0f` | [`tts_vits_rtx4090_2026-07-31.json`](https://github.com/kadirnar/voicehub/blob/main/benchmarks/tts_vits_rtx4090_2026-07-31.json) | Complete tokenizer, acoustic graph, flow, and vocoder path on an RTX 4090 |
+| ASR real checkpoints | Moonshine tiny, Wav2Vec2 base, and Whisper tiny through five adapters | [`asr_vad_rtx4090_2026-07-31.json`](https://github.com/kadirnar/voicehub/blob/main/benchmarks/asr_vad_rtx4090_2026-07-31.json) | Complete transcription paths with deterministic text and single-sample WER; not a corpus accuracy claim |
+| VAD real checkpoints or algorithms | Silero, Sherpa/Silero, WebRTC, and Auditok | Same ASR/VAD JSON evidence | Complete segmentation paths with boundary/score comparisons |
+| Hardware-limited remainder | Gated, restricted, multi-gigabyte, or unavailable checkpoints | Provider documentation and explicit coverage records in benchmark JSON | Pending by design; no claim that every public checkpoint was downloaded |
+
+The readable methodology and results are in the
+[RTX 4090 speech benchmark](../guides/rtx-4090-speech-benchmarks.md). Performance
+numbers are checkpoint- and machine-specific and are not release thresholds on
+other hardware.
+
+## Local release gates
+
+Run from a clean checkout with Python 3.12 after installing
+`.[test,training,docs]`:
+
+```bash
+python scripts/check_release.py
+python -m pytest -q
+pre-commit run --all-files
+mkdocs build --strict --clean
+python scripts/check_distribution.py
+```
+
+The same full suite also passed in independent clean macOS environments on
+Python 3.10.19 (232.20 seconds), Python 3.11.15 (215.65 seconds), and Python
+3.12.12 (99.72 seconds). The 3.10 and 3.11 environments resolved and installed
+their declared test/runtime dependencies from scratch before execution. These
+runs strengthen version compatibility evidence but do not replace the pending
+Linux and Windows candidate CI jobs.
+
+The release workflow first repeats the complete test suite on Linux, macOS,
+and Windows with Python 3.10, 3.11, and 3.12. Its build job cannot begin unless
+all nine tagged-source jobs pass. It then repeats the remaining local gates,
+checks that tag `v0.3.0` points at the checked-out commit, verifies that 0.3.0
+is not already on PyPI, builds one wheel/sdist pair, checks their embedded
+metadata and size, and transfers those exact artifacts to a separate publish
+job.
+
+The latest clean-install build produced a 57,169,593-byte wheel and a
+55,393,745-byte source distribution. Fresh builds passed embedded name/version
+checks; gzip timestamps can change archive bytes, so release hashes are recorded
+from the exact workflow artifacts rather than copied from a local build.
+
+The repository-wide pre-commit gate initially identified 28 existing Python
+files that needed isort, YAPF, or docformatter normalization. They were updated
+as a dedicated mechanical pass. A normalized AST comparison found no behavior-
+tree changes, and the subsequent all-files pre-commit and full test runs passed.
+
+The distribution gate inventories every `SOURCE.json`, license, licence,
+NOTICE, and COPYING file under the installed package. Each of the 81 source
+manifests must contain a pinned revision/release and explicit license metadata;
+all 193 compliance files plus the project-level Apache-2.0 license must survive
+both wheel and source-distribution builds.
+
+The latest committed `main` baseline also passed Package CI and the strict
+documentation/deployment workflow in
+[runs 30687784386](https://github.com/kadirnar/voicehub/actions/runs/30687784386)
+and [30687784381](https://github.com/kadirnar/voicehub/actions/runs/30687784381).
+Those runs predate the uncommitted release-candidate changes and are recorded
+only as baseline evidence, not as a pass for the candidate.
+
+## One-time publisher configuration
+
+Before the first 0.3 publication:
+
+1. In PyPI project settings, add a GitHub Trusted Publisher for repository
+   `kadirnar/voicehub`, workflow `release.yml`, and environment `pypi`.
+2. In GitHub, create the `pypi` environment and require a maintainer reviewer.
+3. Do not add a long-lived PyPI API token. Only the publish job receives
+   `id-token: write`.
+
+PyPI's default per-file limit is 100 MB. `scripts/check_release.py --dist-dir`
+rejects oversized or unexpected files before the protected publish job begins.
+
+## Publish and post-publish verification
+
+After every local and cross-platform gate is green, create the signed tag and
+manually dispatch the release workflow with its publish confirmation enabled.
+Approve the protected `pypi` environment only after reviewing the build job and
+artifact hashes.
+
+When PyPI finishes indexing the release, verify external parity:
+
+```bash
+python scripts/check_release.py \
+  --tag v0.3.0 \
+  --require-tag-at-head \
+  --pypi-policy published
+```
+
+Only then create or finalize the matching GitHub release. If any external gate
+fails, leave the candidate unpublished and record the exact blocker here.

--- a/docs/project/release-readiness.md
+++ b/docs/project/release-readiness.md
@@ -21,9 +21,9 @@ contract.
 | Source, docs, benchmark, and PyPI candidate alignment | Local check identified 0.3.0 as a new candidate over PyPI 0.1.6 | Passed |
 | Full CPU-safe suite | Clean macOS runs on Python 3.10, 3.11, and 3.12 each reported 2,343 passed, 25 skipped, 2,593 subtests, and 35 warnings | Passed locally across supported Python versions |
 | Formatting and lint | Repository-wide pre-commit completed after a dedicated 28-file mechanical normalization; a normalized AST audit found no behavior-tree changes | Passed |
-| Documentation | Strict multilingual build completed locally | Passed |
-| Wheel, sdist, and editable installs | All three clean probes reported 68 models, 81 pinned/license-bearing source manifests, 193 installed provenance/legal files, required data present, zero dependency violations, and no eager PyTorch import | Passed |
-| Python 3.10–3.12 on Linux, macOS, and Windows | The committed baseline `03f6884` passed all nine jobs in [CI run 30687784383](https://github.com/kadirnar/voicehub/actions/runs/30687784383); CI and the protected release workflow both define the full 3×3 matrix | Baseline passed; candidate execution pending |
+| Documentation | Strict multilingual build completed locally and in [candidate Docs run 30691669774](https://github.com/kadirnar/voicehub/actions/runs/30691669774) | Passed |
+| Wheel, sdist, and editable installs | All three clean probes reported 68 models, 81 pinned/license-bearing source manifests, 193 installed provenance/legal files, required data present, zero dependency violations, and no eager PyTorch import; [candidate Package CI run 30691669796](https://github.com/kadirnar/voicehub/actions/runs/30691669796) repeated the release and distribution checks | Passed |
+| Python 3.10–3.12 on Linux, macOS, and Windows | Candidate commit `e2bfb4a` passed all nine matrix jobs in [CI run 30691669734](https://github.com/kadirnar/voicehub/actions/runs/30691669734), plus macOS and Windows runtime smokes, default-runtime, training, and lint jobs | Passed |
 | Released-checkpoint TTS, ASR, and VAD evidence | Dated RTX 4090 JSON and guide; see matrix below | Passed for the listed representatives |
 | Tokenless publication workflow | Source contract test verifies separate build/publish jobs, protected environment, and job-scoped OIDC | Passed locally; tagged run pending |
 | Protected `pypi` environment and PyPI publisher | GitHub's environment inventory currently contains only `github-pages`; PyPI publisher settings require maintainer access | Pending maintainer configuration |
@@ -66,8 +66,8 @@ The same full suite also passed in independent clean macOS environments on
 Python 3.10.19 (232.20 seconds), Python 3.11.15 (215.65 seconds), and Python
 3.12.12 (99.72 seconds). The 3.10 and 3.11 environments resolved and installed
 their declared test/runtime dependencies from scratch before execution. These
-runs strengthen version compatibility evidence but do not replace the pending
-Linux and Windows candidate CI jobs.
+runs supplied pre-push evidence; candidate CI subsequently passed the same
+supported Python versions on Linux, macOS, and Windows.
 
 The release workflow first repeats the complete test suite on Linux, macOS,
 and Windows with Python 3.10, 3.11, and 3.12. Its build job cannot begin unless
@@ -93,12 +93,13 @@ manifests must contain a pinned revision/release and explicit license metadata;
 all 193 compliance files plus the project-level Apache-2.0 license must survive
 both wheel and source-distribution builds.
 
-The latest committed `main` baseline also passed Package CI and the strict
-documentation/deployment workflow in
-[runs 30687784386](https://github.com/kadirnar/voicehub/actions/runs/30687784386)
-and [30687784381](https://github.com/kadirnar/voicehub/actions/runs/30687784381).
-Those runs predate the uncommitted release-candidate changes and are recorded
-only as baseline evidence, not as a pass for the candidate.
+Candidate commit `e2bfb4a` passed Continuous Integration, Package CI, and the
+strict documentation build in
+[runs 30691669734](https://github.com/kadirnar/voicehub/actions/runs/30691669734),
+[30691669796](https://github.com/kadirnar/voicehub/actions/runs/30691669796), and
+[30691669774](https://github.com/kadirnar/voicehub/actions/runs/30691669774).
+The pull request intentionally skipped GitHub Pages deployment; deployment is
+not a candidate test gate.
 
 ## One-time publisher configuration
 

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -1,0 +1,46 @@
+---
+description: Evidence-first roadmap for the VoiceHub 0.3 release line.
+release: 0.3.0
+---
+
+# Roadmap
+
+VoiceHub 0.3 is in release-hardening mode. The project is not accepting another
+model family into the built-in registry until the current TTS, ASR, and VAD
+surface has passed the [release-readiness gates](release-readiness.md).
+
+## Current milestone: 0.3 release candidate
+
+The milestone has four ordered outcomes:
+
+1. Keep source, documentation, benchmark evidence, Git tags, and distribution
+   metadata on one version.
+2. Prove that the wheel and source distribution install in clean environments
+   and contain every registered runtime and required data file.
+3. Separate all-provider contract coverage from the smaller set of public
+   checkpoints that have run end to end on recorded hardware.
+4. Publish only the artifacts that passed the release workflow, using PyPI
+   Trusted Publishing and a protected GitHub `pypi` environment.
+
+New providers, unmeasured performance claims, and approximate optimizations as
+defaults are outside this milestone.
+
+## Completed scope discovery
+
+The registry currently exposes 68 integrations: 34 TTS, 23 ASR, and 11 VAD.
+Each has generated documentation, lazy construction, a normalized task output,
+an explicit training boundary, and a default-installation contract.
+
+The historical [GitHub roadmap issue #14](https://github.com/kadirnar/voicehub/issues/14)
+listed LLaSA, Chatterbox, ConversationTTS, CosyVoice, F5-TTS, GPT-SoVITS,
+Kokoro, MeloTTS, OpenVoice, OuteTTS, Parler-TTS, StyleTTS 2, Orpheus, Dia,
+and Vui. Those families are now integrated. The issue is retained as historical
+context; updating or closing it is an external maintainer action, not a release
+automation step.
+
+## After 0.3
+
+Post-release work must start from user demand and reproducible evidence. A new
+provider needs the same package, license, checkpoint, contract, and hardware
+evidence as the current registry. A serving or optimization feature needs a
+measured quality boundary before it can become an automatic default.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,6 +157,8 @@ nav:
       - Trainer architecture: concepts/trainer.md
   - API Reference: reference/api.md
   - Contributing:
+      - Roadmap: project/roadmap.md
+      - Release readiness: project/release-readiness.md
       - Add a TTS model: project/adding-a-model.md
       - Add an ASR or VAD provider: project/adding-speech-provider.md
       - Add an optimization: project/adding-an-optimization.md

--- a/scripts/check_distribution.py
+++ b/scripts/check_distribution.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Build and install-check VoiceHub's wheel, sdist, and editable source tree.
 
-The default check skips runtime dependencies so it can validate packaging
-without downloading PyTorch. Pass ``--with-dependencies`` for a complete
-dependency installation on a release machine.
+The default check skips runtime dependencies so it can validate
+packaging without downloading PyTorch. Pass ``--with-dependencies`` for
+a complete dependency installation on a release machine.
 """
 
 from __future__ import annotations
@@ -18,16 +18,65 @@ from pathlib import Path
 from zipfile import ZipFile
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
-REQUIRED_PACKAGE_FILES = (
+REPRESENTATIVE_PACKAGE_FILES = (
     "voicehub/py.typed",
     "voicehub/architectures/outetts/default_speaker.json",
     "voicehub/models/conversationtts/source/conversationtts/llama3_2/tokenizer.json",
-    (
-        "voicehub/models/chatterbox/source/perth/perth_net/pretrained/implicit/"
-        "perth_net_250000.pth.tar"
-    ),
+    ("voicehub/models/chatterbox/source/perth/perth_net/pretrained/implicit/"
+     "perth_net_250000.pth.tar"),
     "voicehub/kernels/csrc/activations.cpp",
 )
+COMPLIANCE_NAME_TOKENS = ("LICENSE", "LICENCE", "NOTICE", "COPYING")
+
+
+def compliance_package_files(repository_root: Path = REPOSITORY_ROOT) -> tuple[str, ...]:
+    """List every provenance manifest and legal notice shipped in
+    ``voicehub``."""
+    package_root = repository_root / "voicehub"
+    return tuple(
+        sorted(
+            path.relative_to(repository_root).as_posix() for path in package_root.rglob("*")
+            if path.is_file() and (
+                path.name == "SOURCE.json" or any(
+                    token in path.name.upper() for token in COMPLIANCE_NAME_TOKENS))))
+
+
+COMPLIANCE_PACKAGE_FILES = compliance_package_files()
+REQUIRED_PACKAGE_FILES = tuple(dict.fromkeys((*REPRESENTATIVE_PACKAGE_FILES, *COMPLIANCE_PACKAGE_FILES)))
+
+
+def _manifest_values(value: object, key_tokens: tuple[str, ...]) -> list[object]:
+    values: list[object] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            normalized_key = str(key).lower()
+            if (any(token in normalized_key for token in key_tokens) and child not in (None, "", [], {})):
+                values.append(child)
+            values.extend(_manifest_values(child, key_tokens))
+    elif isinstance(value, list):
+        for child in value:
+            values.extend(_manifest_values(child, key_tokens))
+    return values
+
+
+def validate_provenance_manifests(repository_root: Path = REPOSITORY_ROOT) -> int:
+    """Require every retained source manifest to pin origin and license
+    terms."""
+    manifest_paths = sorted((repository_root / "voicehub").rglob("SOURCE.json"))
+    if not manifest_paths:
+        raise RuntimeError("No source provenance manifests were found.")
+    for path in manifest_paths:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise RuntimeError(f"Could not read provenance manifest {path}: {error}") from error
+        if not isinstance(payload, dict) or not payload:
+            raise RuntimeError(f"Provenance manifest {path} must contain a JSON object.")
+        if not _manifest_values(payload, ("revision", "release", "commit", "tag")):
+            raise RuntimeError(f"Provenance manifest {path} does not pin an upstream source.")
+        if not _manifest_values(payload, ("license", "licence")):
+            raise RuntimeError(f"Provenance manifest {path} does not record license terms.")
+    return len(manifest_paths)
 
 
 def run(*command: str | Path, cwd: Path | None = None) -> None:
@@ -67,6 +116,19 @@ def require_members(kind: str, members: set[str]) -> None:
     missing = sorted(set(REQUIRED_PACKAGE_FILES) - members)
     if missing:
         raise RuntimeError(f"{kind} is missing required package data: {missing}")
+
+
+def require_project_license(kind: str, members: set[str]) -> None:
+    """Require the project license in both standard distribution layouts."""
+    if kind == "wheel":
+        licenses = sorted(member for member in members if member.endswith(".dist-info/licenses/LICENSE"))
+        if len(licenses) != 1:
+            raise RuntimeError(f"wheel must contain one dist-info project LICENSE; found {licenses}")
+    elif kind == "sdist":
+        if "LICENSE" not in members:
+            raise RuntimeError("sdist is missing the project LICENSE")
+    else:
+        raise ValueError(f"Unknown distribution kind: {kind}")
 
 
 def create_venv(path: Path) -> Path:
@@ -127,6 +189,17 @@ if not all(required.values()):
     raise RuntimeError(f"Missing installed package data: {required}")
 
 package_root = Path(str(files("voicehub")))
+compliance_files = sorted(
+    path for path in package_root.rglob("*")
+    if path.is_file() and (path.name == "SOURCE.json" or any(
+        token in path.name.upper() for token in ("LICENSE", "LICENCE", "NOTICE", "COPYING")))
+)
+expected_compliance_files = int(sys.argv[1])
+if len(compliance_files) != expected_compliance_files:
+    raise RuntimeError(
+        "Installed compliance inventory is incomplete: "
+        f"{len(compliance_files)} files, expected {expected_compliance_files}"
+    )
 violations = inspect_native_runtime(package_root)
 if violations:
     raise RuntimeError(
@@ -154,10 +227,11 @@ print(json.dumps({
     "torch_imported": "torch" in sys.modules,
     "required_data": required,
     "runtime_dependency_violations": len(violations),
+    "compliance_files": len(compliance_files),
 }))
 """
     completed = subprocess.run(
-        [str(python), "-c", probe],
+        [str(python), "-c", probe, str(len(COMPLIANCE_PACKAGE_FILES))],
         cwd=root,
         check=True,
         capture_output=True,
@@ -180,6 +254,7 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     options = parse_args()
+    provenance_manifests = validate_provenance_manifests()
     with tempfile.TemporaryDirectory(prefix="voicehub-distribution-") as directory:
         root = Path(directory)
         dist = root / "dist"
@@ -198,29 +273,34 @@ def main() -> None:
         wheels = sorted(dist.glob("voicehub-*.whl"))
         sdists = sorted(dist.glob("voicehub-*.tar.gz"))
         if len(wheels) != 1 or len(sdists) != 1:
-            raise RuntimeError(
-                f"Expected one wheel and one sdist, found {wheels!r} and {sdists!r}"
-            )
+            raise RuntimeError(f"Expected one wheel and one sdist, found {wheels!r} and {sdists!r}")
 
-        require_members("wheel", wheel_members(wheels[0]))
-        require_members("sdist", sdist_members(sdists[0]))
+        wheel_files = wheel_members(wheels[0])
+        sdist_files = sdist_members(sdists[0])
+        require_members("wheel", wheel_files)
+        require_members("sdist", sdist_files)
+        require_project_license("wheel", wheel_files)
+        require_project_license("sdist", sdist_files)
 
         results = {
-            "wheel": install_and_probe(
+            "wheel":
+            install_and_probe(
                 "wheel",
                 wheels[0],
                 root=root,
                 editable=False,
                 with_dependencies=options.with_dependencies,
             ),
-            "sdist": install_and_probe(
+            "sdist":
+            install_and_probe(
                 "sdist",
                 sdists[0],
                 root=root,
                 editable=False,
                 with_dependencies=options.with_dependencies,
             ),
-            "editable": install_and_probe(
+            "editable":
+            install_and_probe(
                 "editable",
                 REPOSITORY_ROOT,
                 root=root,
@@ -230,13 +310,16 @@ def main() -> None:
         }
         versions = {str(result["version"]) for result in results.values()}
         model_counts = {int(result["models"]) for result in results.values()}
-        if len(versions) != 1 or len(model_counts) != 1:
+        compliance_counts = {int(result["compliance_files"]) for result in results.values()}
+        if len(versions) != 1 or len(model_counts) != 1 or len(compliance_counts) != 1:
             raise RuntimeError(f"Installation modes disagree: {results}")
 
         print(
             "PASS:",
             f"version={versions.pop()}",
             f"models={model_counts.pop()}",
+            f"provenance_manifests={provenance_manifests}",
+            f"compliance_files={compliance_counts.pop()}",
             f"wheel_bytes={wheels[0].stat().st_size}",
             f"sdist_bytes={sdists[0].stat().st_size}",
         )

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""Validate VoiceHub source, evidence, artifacts, tags, and PyPI release
+state."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import subprocess
+import tarfile
+import urllib.request
+from email.parser import Parser
+from pathlib import Path
+from typing import Any
+from zipfile import ZipFile
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+PYPI_JSON_URL = "https://pypi.org/pypi/voicehub/json"
+PYPI_DEFAULT_FILE_LIMIT = 100_000_000
+VERSION_PATTERN = re.compile(r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)")
+WHEEL_VERSION_PATTERN = re.compile(r"voicehub-(\d+\.\d+\.\d+)-py3-none-any\.whl")
+
+
+class ReleaseCheckError(RuntimeError):
+    """Raised when release evidence contradicts the candidate contract."""
+
+
+def parse_version(value: str) -> tuple[int, int, int]:
+    """Parse the stable semantic version format used by VoiceHub releases."""
+    if VERSION_PATTERN.fullmatch(value) is None:
+        raise ReleaseCheckError(
+            f"VoiceHub release versions must use stable X.Y.Z syntax; received {value!r}.")
+    major, minor, patch = value.split(".")
+    return int(major), int(minor), int(patch)
+
+
+def source_version(repository_root: Path = REPOSITORY_ROOT) -> str:
+    """Read ``voicehub.__version__`` without importing the package."""
+    init_path = repository_root / "voicehub" / "__init__.py"
+    module = ast.parse(init_path.read_text(encoding="utf-8"), filename=str(init_path))
+    for statement in module.body:
+        if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = statement.targets if isinstance(statement, ast.Assign) else (statement.target, )
+        if not any(isinstance(target, ast.Name) and target.id == "__version__" for target in targets):
+            continue
+        value = ast.literal_eval(statement.value)
+        if not isinstance(value, str):
+            break
+        parse_version(value)
+        return value
+    raise ReleaseCheckError(f"Could not read a string __version__ assignment from {init_path}.")
+
+
+def validate_source_metadata(version: str, repository_root: Path = REPOSITORY_ROOT) -> None:
+    """Require packaging metadata to resolve its version from the public
+    package."""
+    pyproject = (repository_root / "pyproject.toml").read_text(encoding="utf-8")
+    required_fragments = (
+        'name = "voicehub"',
+        'dynamic = ["version"]',
+        'description = "A unified inference and training interface for TTS, ASR, and VAD models"',
+        'version = { attr = "voicehub.__version__" }',
+        'requires-python = ">=3.10"',
+    )
+    missing = [fragment for fragment in required_fragments if fragment not in pyproject]
+    if missing:
+        raise ReleaseCheckError(f"pyproject.toml is missing release metadata: {missing}")
+    if f'__version__ = "{version}"' not in (repository_root / "voicehub" /
+                                            "__init__.py").read_text(encoding="utf-8"):
+        raise ReleaseCheckError("The parsed source version does not have one canonical assignment.")
+
+
+def _voicehub_versions(value: Any) -> list[str]:
+    versions: list[str] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key == "voicehub_version":
+                versions.append(str(child))
+            versions.extend(_voicehub_versions(child))
+    elif isinstance(value, list):
+        for child in value:
+            versions.extend(_voicehub_versions(child))
+    return versions
+
+
+def validate_benchmark_versions(version: str, repository_root: Path = REPOSITORY_ROOT) -> int:
+    """Require every retained JSON evidence file to identify the source
+    version."""
+    benchmark_paths = tuple(sorted((repository_root / "benchmarks").glob("*.json")))
+    if not benchmark_paths:
+        raise ReleaseCheckError("No benchmark evidence files were found.")
+    for path in benchmark_paths:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        versions = _voicehub_versions(payload)
+        if not versions:
+            raise ReleaseCheckError(f"{path.name} does not record voicehub_version.")
+        mismatched = sorted(set(versions) - {version})
+        if mismatched:
+            raise ReleaseCheckError(f"{path.name} records versions {mismatched}, expected only {version}.")
+    return len(benchmark_paths)
+
+
+def _front_matter_value(source: str, key: str) -> str | None:
+    if not source.startswith("---\n"):
+        return None
+    front_matter = source.split("---\n", 2)[1]
+    match = re.search(rf"^{re.escape(key)}:\s*[\"']?([^\n\"']+)[\"']?\s*$", front_matter, re.MULTILINE)
+    return match.group(1).strip() if match is not None else None
+
+
+def validate_documentation_version(version: str, repository_root: Path = REPOSITORY_ROOT) -> None:
+    """Keep the release report and versioned install examples aligned."""
+    for relative_path in (
+            "docs/project/release-readiness.md",
+            "docs/project/roadmap.md",
+    ):
+        path = repository_root / relative_path
+        documented_version = _front_matter_value(path.read_text(encoding="utf-8"), "release")
+        if documented_version != version:
+            raise ReleaseCheckError(
+                f"{relative_path} records release {documented_version!r}, expected {version!r}.")
+
+    readme = (repository_root / "README.md").read_text(encoding="utf-8")
+    readme_contract = (
+        "One Python interface for text-to-speech, speech recognition, and voice activity detection.",
+        "The 0.3 release line is an evidence-first unified open-speech runtime",
+        "VoiceHub supports Python 3.10 through 3.12.",
+    )
+    missing_contract = [fragment for fragment in readme_contract if fragment not in readme]
+    if missing_contract:
+        raise ReleaseCheckError(f"README.md is missing the 0.3 product contract: {missing_contract}")
+
+    documented_wheel_versions: set[str] = set()
+    for root in (repository_root / "README.md", repository_root / "docs"):
+        paths = (root, ) if root.is_file() else tuple(root.rglob("*.md"))
+        for path in paths:
+            documented_wheel_versions.update(WHEEL_VERSION_PATTERN.findall(path.read_text(encoding="utf-8")))
+    if documented_wheel_versions - {version}:
+        raise ReleaseCheckError(
+            "Versioned wheel examples disagree with the source version: "
+            f"{sorted(documented_wheel_versions)} versus {version}.")
+
+
+def _read_evidence(repository_root: Path, filename: str) -> dict[str, Any]:
+    path = repository_root / "benchmarks" / filename
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ReleaseCheckError(f"Could not read benchmark evidence {path}: {error}") from error
+    if not isinstance(payload, dict):
+        raise ReleaseCheckError(f"Benchmark evidence {path} must contain a JSON object.")
+    return payload
+
+
+def validate_layered_evidence(repository_root: Path = REPOSITORY_ROOT) -> dict[str, int]:
+    """Prove the all-provider contract matrix and representative real runs
+    coexist."""
+    tts = _read_evidence(repository_root, "tts_optimization_rtx4090_2026-07-31.json")
+    speech_input = _read_evidence(repository_root, "asr_vad_rtx4090_2026-07-31.json")
+    vits = _read_evidence(repository_root, "tts_vits_rtx4090_2026-07-31.json")
+    rejected_vui = _read_evidence(repository_root, "tts_vui_rtx4090_rejected_2026-07-31.json")
+
+    tts_providers = tts.get("providers")
+    if not isinstance(tts_providers, list) or len(tts_providers) != 34:
+        raise ReleaseCheckError("TTS evidence must contain exactly 34 provider rows.")
+    tts_types = {str(row.get("model_type", "")) for row in tts_providers if isinstance(row, dict)}
+    if len(tts_types) != 34 or "" in tts_types:
+        raise ReleaseCheckError("TTS evidence contains missing or duplicate model types.")
+    incomplete_tts = []
+    for row in tts_providers:
+        if not isinstance(row, dict):
+            incomplete_tts.append(repr(row))
+        elif (row.get("static_plan_status") != "passed" or not row.get("evidence") or not row.get("note")):
+            incomplete_tts.append(str(row.get("model_type")))
+    incomplete_tts.sort()
+    if incomplete_tts:
+        raise ReleaseCheckError(f"TTS provider rows lack contract evidence: {incomplete_tts}")
+
+    coverage = speech_input.get("coverage")
+    if not isinstance(coverage, list) or len(coverage) != 34:
+        raise ReleaseCheckError("ASR/VAD evidence must contain exactly 34 provider rows.")
+    speech_input_types = {str(row.get("model_type", "")) for row in coverage if isinstance(row, dict)}
+    if len(speech_input_types) != 34 or "" in speech_input_types:
+        raise ReleaseCheckError("ASR/VAD evidence contains missing or duplicate model types.")
+    task_counts = {
+        "asr": sum(model_type.startswith("asr_") for model_type in speech_input_types),
+        "vad": sum(model_type.startswith("vad_") for model_type in speech_input_types),
+    }
+    if task_counts != {"asr": 23, "vad": 11}:
+        raise ReleaseCheckError(f"ASR/VAD evidence has unexpected task counts: {task_counts}")
+
+    allowed_verification = {
+        "external-checkpoint-blocker",
+        "real-algorithm",
+        "real-checkpoint",
+        "tiny-native-graph",
+    }
+    invalid_rows = []
+    for row in coverage:
+        if not isinstance(row, dict) or row.get("verification") not in allowed_verification:
+            invalid_rows.append(str(row.get("model_type") if isinstance(row, dict) else row))
+        elif (row["verification"] == "external-checkpoint-blocker" and not row.get("blocker")):
+            invalid_rows.append(str(row.get("model_type")))
+    if invalid_rows:
+        raise ReleaseCheckError(f"ASR/VAD evidence has invalid verification rows: {invalid_rows}")
+    for prefix in ("asr_", "vad_"):
+        if not any(str(row["model_type"]).startswith(prefix) and
+                   row["verification"] in {"real-checkpoint", "real-algorithm"} for row in coverage):
+            raise ReleaseCheckError(f"No representative real evidence exists for task prefix {prefix!r}.")
+
+    documented_types = {
+        path.stem
+        for path in (repository_root / "docs" / "models" / "providers").glob("*.md")
+        if path.name != "index.md"
+    }
+    evidence_types = tts_types | speech_input_types
+    if documented_types != evidence_types:
+        raise ReleaseCheckError(
+            "Provider guides and layered evidence disagree: "
+            f"missing guides={sorted(evidence_types - documented_types)}, "
+            f"missing evidence={sorted(documented_types - evidence_types)}")
+
+    checkpoint = vits.get("checkpoint")
+    coverage_summary = vits.get("coverage_summary")
+    if (not isinstance(checkpoint, dict) or checkpoint.get("model_type") != "vits" or
+            not checkpoint.get("resolved_revision") or not isinstance(coverage_summary, dict) or
+            coverage_summary.get("real_checkpoint_inference_models") != 1):
+        raise ReleaseCheckError("VITS evidence does not prove a pinned real-checkpoint TTS run.")
+    policy = rejected_vui.get("policy")
+    if (rejected_vui.get("status") != "rejected" or not isinstance(policy, dict) or
+            policy.get("inference_torch_compile") != "rejected"):
+        raise ReleaseCheckError("Rejected VUI optimization evidence is not fail-closed.")
+
+    return {
+        "tts_providers": len(tts_types),
+        "asr_providers": task_counts["asr"],
+        "vad_providers": task_counts["vad"],
+        "documented_providers": len(documented_types),
+    }
+
+
+def validate_tag(tag: str, version: str) -> None:
+    expected = f"v{version}"
+    if tag != expected:
+        raise ReleaseCheckError(f"Release tag {tag!r} must exactly match {expected!r}.")
+
+
+def _git_output(repository_root: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ["git", *arguments],
+        cwd=repository_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise ReleaseCheckError(f"git {' '.join(arguments)} failed: {detail}")
+    return completed.stdout.strip()
+
+
+def validate_tag_at_head(tag: str, repository_root: Path = REPOSITORY_ROOT) -> None:
+    """Reject publishing from a branch or from a tag that points elsewhere."""
+    tag_commit = _git_output(repository_root, "rev-parse", "--verify", f"refs/tags/{tag}^{{commit}}")
+    head_commit = _git_output(repository_root, "rev-parse", "HEAD")
+    if tag_commit != head_commit:
+        raise ReleaseCheckError(
+            f"Tag {tag!r} points to {tag_commit}, but the checked-out commit is {head_commit}.")
+
+
+def _metadata(text: str, *, source: str) -> dict[str, str]:
+    message = Parser().parsestr(text)
+    values = {name: str(message.get(name, "")).strip() for name in ("Name", "Version")}
+    if not all(values.values()):
+        raise ReleaseCheckError(f"{source} is missing Name or Version metadata.")
+    return values
+
+
+def _validate_distribution_metadata(values: dict[str, str], version: str, *, source: str) -> None:
+    if values != {"Name": "voicehub", "Version": version}:
+        raise ReleaseCheckError(f"{source} metadata is {values}, expected VoiceHub {version}.")
+
+
+def validate_distributions(
+    dist_dir: Path,
+    version: str,
+) -> dict[str, int]:
+    """Verify the exact wheel/sdist pair that the publish job will upload."""
+    wheel = dist_dir / f"voicehub-{version}-py3-none-any.whl"
+    sdist = dist_dir / f"voicehub-{version}.tar.gz"
+    distributions = tuple(sorted(path for path in dist_dir.iterdir() if path.is_file()))
+    if len(distributions) != 2 or set(distributions) != {sdist, wheel}:
+        raise ReleaseCheckError(
+            "The release directory must contain only the expected wheel and sdist; "
+            f"found {[path.name for path in distributions]}.")
+
+    sizes = {path.name: path.stat().st_size for path in distributions}
+    oversized = {name: size for name, size in sizes.items() if size > PYPI_DEFAULT_FILE_LIMIT}
+    if oversized:
+        raise ReleaseCheckError(f"Distribution files exceed PyPI's default 100 MB limit: {oversized}")
+
+    with ZipFile(wheel) as archive:
+        metadata_path = f"voicehub-{version}.dist-info/METADATA"
+        try:
+            values = _metadata(
+                archive.read(metadata_path).decode("utf-8"),
+                source=f"{wheel.name}:{metadata_path}",
+            )
+        except KeyError as error:
+            raise ReleaseCheckError(f"{wheel.name} is missing {metadata_path}.") from error
+        _validate_distribution_metadata(values, version, source=wheel.name)
+
+    with tarfile.open(sdist) as archive:
+        metadata_path = f"voicehub-{version}/PKG-INFO"
+        try:
+            member = archive.getmember(metadata_path)
+            extracted = archive.extractfile(member)
+        except KeyError as error:
+            raise ReleaseCheckError(f"{sdist.name} is missing {metadata_path}.") from error
+        if extracted is None:
+            raise ReleaseCheckError(f"Could not read {metadata_path} from {sdist.name}.")
+        values = _metadata(
+            extracted.read().decode("utf-8"),
+            source=f"{sdist.name}:{metadata_path}",
+        )
+        _validate_distribution_metadata(values, version, source=sdist.name)
+    return sizes
+
+
+def fetch_pypi_payload(url: str = PYPI_JSON_URL) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "voicehub-release-check/0.3"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            payload = json.load(response)
+    except Exception as error:
+        raise ReleaseCheckError(f"Could not read the PyPI release state: {error}") from error
+    if not isinstance(payload, dict):
+        raise ReleaseCheckError("PyPI returned a non-object JSON payload.")
+    return payload
+
+
+def validate_pypi_payload(
+    payload: dict[str, Any],
+    version: str,
+    policy: str,
+) -> str:
+    """Validate either a not-yet-published candidate or a completed release."""
+    try:
+        latest = str(payload["info"]["version"])
+        releases = payload["releases"]
+    except (KeyError, TypeError) as error:
+        raise ReleaseCheckError("PyPI payload is missing info.version or releases.") from error
+    if not isinstance(releases, dict):
+        raise ReleaseCheckError("PyPI releases must be a JSON object.")
+
+    if policy == "candidate":
+        if version in releases and releases[version]:
+            raise ReleaseCheckError(f"VoiceHub {version} is already present on PyPI.")
+        if parse_version(latest) >= parse_version(version):
+            raise ReleaseCheckError(f"PyPI latest version {latest} is not older than candidate {version}.")
+    elif policy == "published":
+        if latest != version or not releases.get(version):
+            raise ReleaseCheckError(
+                f"PyPI latest version is {latest}; published verification expected {version}.")
+    else:
+        raise ValueError(f"Unknown PyPI policy: {policy}")
+    return latest
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", help="Expected release tag, for example v0.3.0.")
+    parser.add_argument(
+        "--require-tag-at-head",
+        action="store_true",
+        help="Require --tag to exist and point at the checked-out commit.",
+    )
+    parser.add_argument(
+        "--dist-dir",
+        type=Path,
+        help="Directory containing the exact wheel and sdist pair to validate.",
+    )
+    parser.add_argument(
+        "--pypi-policy",
+        choices=("candidate", "published"),
+        help="Validate PyPI before publishing or after the release is visible.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    options = parse_args()
+    version = source_version()
+    report: dict[str, Any] = {"version": version}
+
+    validate_source_metadata(version)
+    report["benchmark_files"] = validate_benchmark_versions(version)
+    report["layered_evidence"] = validate_layered_evidence()
+    validate_documentation_version(version)
+    report["source_metadata"] = "passed"
+    report["documentation_version"] = "passed"
+
+    if options.require_tag_at_head and not options.tag:
+        raise ReleaseCheckError("--require-tag-at-head also requires --tag.")
+    if options.tag:
+        validate_tag(options.tag, version)
+        report["tag"] = options.tag
+        if options.require_tag_at_head:
+            validate_tag_at_head(options.tag)
+            report["tag_at_head"] = "passed"
+    if options.dist_dir:
+        report["distribution_bytes"] = validate_distributions(options.dist_dir, version)
+    if options.pypi_policy:
+        payload = fetch_pypi_payload()
+        report["pypi_latest"] = validate_pypi_payload(payload, version, options.pypi_policy)
+        report["pypi_policy"] = options.pypi_policy
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_finetune_vits.py
+++ b/scripts/smoke_finetune_vits.py
@@ -2,10 +2,11 @@
 """Run one reproducible real-checkpoint VITS generator warm-start step.
 
 MMS-TTS metadata does not publish the original FFT, hop, window, mel, or
-segment recipe. This smoke test therefore exercises VoiceHub's explicitly
-preprocessed generator warm-start, not the complete adversarial VITS recipe.
-It creates one short example from the base checkpoint, takes one deterministic
-step, exports native Safetensors, reloads them, and runs long-form inference.
+segment recipe. This smoke test therefore exercises VoiceHub's
+explicitly preprocessed generator warm-start, not the complete
+adversarial VITS recipe. It creates one short example from the base
+checkpoint, takes one deterministic step, exports native Safetensors,
+reloads them, and runs long-form inference.
 """
 
 from __future__ import annotations
@@ -21,16 +22,14 @@ from typing import Any
 
 TRAINING_TEXT = (
     "VoiceHub makes speech model inference easier, clearer, and more "
-    "reproducible for every user."
-)
+    "reproducible for every user.")
 VALIDATION_TEXT = (
     "VoiceHub makes speech model inference easier to understand and reproduce. "
     "This sample is intentionally long enough to produce more than ten seconds "
     "of clear spoken audio. It measures the complete text tokenizer, acoustic "
     "model, normalizing flow, and neural vocoder pipeline on one graphics "
     "processor. The same sentence and random seed are used for every benchmark "
-    "so that baseline and fine-tuned runs remain directly comparable."
-)
+    "so that baseline and fine-tuned runs remain directly comparable.")
 _UNSET = object()
 
 
@@ -136,11 +135,8 @@ def checkpoint_identity(
     resolved_source = getattr(artifacts, "source", None)
     resolved_revision = getattr(artifacts, "revision", None)
     revision_was_explicit = requested_revision is not None
-    if (
-            requested_revision is None
-            and getattr(config, "model_type", None) == "vits"
-            and resolved_revision is not None
-    ):
+    if (requested_revision is None and getattr(config, "model_type", None) == "vits" and
+            resolved_revision is not None):
         requested_revision = "main"
     checkpoint_value = getattr(artifacts, "checkpoint", None)
     checkpoint_path = None
@@ -150,27 +146,22 @@ def checkpoint_identity(
             checkpoint_path = candidate_path.resolve()
     weight_path = (
         checkpoint_path
-        if checkpoint_path is not None
-        and not checkpoint_path.name.endswith(".index.json")
-        else None
-    )
+        if checkpoint_path is not None and not checkpoint_path.name.endswith(".index.json") else None)
     return {
-        "requested_source": str(requested_source),
-        "requested_revision": requested_revision,
-        "requested_revision_was_explicit": revision_was_explicit,
-        "resolved_source": (
-            None if resolved_source is None else str(resolved_source)),
-        "resolved_revision": resolved_revision,
-        "local_checkpoint_path": (
-            None if checkpoint_path is None else str(checkpoint_path)),
-        "local_weight_sha256": (
-            None if weight_path is None else _sha256_file(weight_path)),
+        "requested_source":
+        str(requested_source),
+        "requested_revision":
+        requested_revision,
+        "requested_revision_was_explicit":
+        revision_was_explicit,
+        "resolved_source": (None if resolved_source is None else str(resolved_source)),
+        "resolved_revision":
+        resolved_revision,
+        "local_checkpoint_path": (None if checkpoint_path is None else str(checkpoint_path)),
+        "local_weight_sha256": (None if weight_path is None else _sha256_file(weight_path)),
         "weight_digest_status": (
-            "sha256"
-            if weight_path is not None else
-            "checkpoint-index-only"
-            if checkpoint_path is not None else
-            "not-exposed"),
+            "sha256" if weight_path is not None else
+            "checkpoint-index-only" if checkpoint_path is not None else "not-exposed"),
     }
 
 
@@ -208,9 +199,7 @@ def _run_seeded(adapter: Any, inputs: dict[str, Any], torch: Any, seed: int):
 def run(args: argparse.Namespace) -> dict[str, Any]:
     import torch
 
-    from voicehub import (
-        AutoModelForTextToSpeech,
-    )
+    from voicehub import AutoModelForTextToSpeech
     from voicehub import __version__ as voicehub_version
 
     destination = prepare_output_directory(args.output_dir)
@@ -289,10 +278,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         args.training_seed,
     )
     loss_before = float(before.loss.detach().float().cpu())
-    losses_before = {
-        name: float(value.detach().float().cpu())
-        for name, value in before.losses.items()
-    }
+    losses_before = {name: float(value.detach().float().cpu()) for name, value in before.losses.items()}
     before.loss.backward()
     gradient_norm = float(
         torch.nn.utils.clip_grad_norm_(
@@ -308,26 +294,19 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         args.training_seed,
     )
     loss_after = float(after.loss.detach().float().cpu())
-    losses_after = {
-        name: float(value.detach().float().cpu())
-        for name, value in after.losses.items()
-    }
+    losses_after = {name: float(value.detach().float().cpu()) for name, value in after.losses.items()}
     trained_fingerprint = state_fingerprint(model.model.state_dict())
 
     export_started = time.perf_counter()
     model.export_native_pretrained(destination)
     export_seconds = time.perf_counter() - export_started
     native_export_files = sorted(
-        str(path.relative_to(destination))
-        for path in destination.iterdir() if path.is_file())
+        str(path.relative_to(destination)) for path in destination.iterdir() if path.is_file())
     del after, before, adapter, optimizer, parameters, inputs, model
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
 
-    reload_config_kwargs = {
-        key: value
-        for key, value in config_kwargs.items() if key != "revision"
-    }
+    reload_config_kwargs = {key: value for key, value in config_kwargs.items() if key != "revision"}
     reloaded = AutoModelForTextToSpeech.from_pretrained(
         destination,
         model_type="vits",
@@ -468,8 +447,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
             "output_file":
             str(validation_path),
             "sha256_float32":
-            hashlib.sha256(
-                validation.audio.detach().float().cpu().numpy().tobytes(order="C")).hexdigest(),
+            hashlib.sha256(validation.audio.detach().float().cpu().numpy().tobytes(order="C")).hexdigest(),
         },
     }
     report_path = destination / "smoke_finetune_report.json"
@@ -521,11 +499,9 @@ def main() -> int:
     result = run(args)
     print(json.dumps(result, allow_nan=False, indent=2, sort_keys=True))
     return int(
-        not result["pre_step_repeat_exact"]
-        or not result["training_forward_matches_precheck"]
-        or not result["state_changed"]
-        or result["loss_after"] >= result["loss_before"]
-        or not result["reload_exact"])
+        not result["pre_step_repeat_exact"] or not result["training_forward_matches_precheck"] or
+        not result["state_changed"] or result["loss_after"] >= result["loss_before"] or
+        not result["reload_exact"])
 
 
 if __name__ == "__main__":

--- a/tests/test_asr_granite_speech.py
+++ b/tests/test_asr_granite_speech.py
@@ -12,10 +12,7 @@ from types import SimpleNamespace
 import torch
 
 from voicehub.architectures.causal_lm.configuration import GraniteConfig
-from voicehub.architectures.granite_speech.artifacts import (
-    GraniteSpeechArtifacts,
-    resolve_granite_speech_artifacts,
-)
+from voicehub.architectures.granite_speech.artifacts import GraniteSpeechArtifacts, resolve_granite_speech_artifacts
 from voicehub.architectures.granite_speech.checkpoint import (
     granite_speech_header_fingerprint,
     math_product,
@@ -27,9 +24,7 @@ from voicehub.architectures.granite_speech.configuration import (
     GraniteSpeechProjectorConfig,
 )
 from voicehub.architectures.granite_speech.frontend import GraniteSpeechFeatureExtractor
-from voicehub.architectures.granite_speech.modeling import (
-    GraniteSpeechForConditionalGeneration,
-)
+from voicehub.architectures.granite_speech.modeling import GraniteSpeechForConditionalGeneration
 from voicehub.architectures.granite_speech.processing import GraniteSpeechProcessor
 from voicehub.architectures.granite_speech.runtime import (
     GraniteSpeechRuntime,

--- a/tests/test_asr_vad_benchmark.py
+++ b/tests/test_asr_vad_benchmark.py
@@ -15,11 +15,7 @@ from types import SimpleNamespace
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = PROJECT_ROOT / "scripts" / "benchmark_asr_vad.py"
-RESULTS = (
-    PROJECT_ROOT
-    / "benchmarks"
-    / "asr_vad_rtx4090_2026-07-31.json"
-)
+RESULTS = (PROJECT_ROOT / "benchmarks" / "asr_vad_rtx4090_2026-07-31.json")
 
 
 class ASRVADBenchmarkScriptTests(unittest.TestCase):
@@ -43,10 +39,7 @@ class ASRVADBenchmarkScriptTests(unittest.TestCase):
         for index in range(sample_rate * 12):
             second = index / sample_rate
             value = (
-                0
-                if second < 1 or second >= 11
-                else round(12_000 * math.sin(2 * math.pi * 220 * second))
-            )
+                0 if second < 1 or second >= 11 else round(12_000 * math.sin(2 * math.pi * 220 * second)))
             samples.append(value)
         with wave.open(str(path), "wb") as output:
             output.setnchannels(1)
@@ -69,10 +62,8 @@ class ASRVADBenchmarkScriptTests(unittest.TestCase):
         self.assertEqual(result["passed"], 34)
         self.assertEqual(result["failed"], 0)
         self.assertEqual(
-            {
-                record["task"]
-                for record in result["providers"]
-            },
+            {record["task"]
+             for record in result["providers"]},
             {
                 "automatic-speech-recognition",
                 "voice-activity-detection",
@@ -80,10 +71,8 @@ class ASRVADBenchmarkScriptTests(unittest.TestCase):
         )
         self.assertTrue(
             all(
-                record["status"] == "lazy-contract-passed"
-                and record["lazy_runtime_allocated"] is False
-                for record in result["providers"]
-            ))
+                record["status"] == "lazy-contract-passed" and record["lazy_runtime_allocated"] is False
+                for record in result["providers"]))
 
     def test_checked_in_results_cover_every_provider(self):
         result = json.loads(RESULTS.read_text(encoding="utf-8"))
@@ -92,13 +81,13 @@ class ASRVADBenchmarkScriptTests(unittest.TestCase):
         self.assertEqual(result["voicehub_version"], "0.3.0")
         self.assertEqual(len(coverage), 34)
         self.assertEqual(
-            len({record["model_type"] for record in coverage}),
+            len({record["model_type"]
+                 for record in coverage}),
             34,
         )
         self.assertEqual(
             sum(
-                result["coverage_summary"][name]
-                for name in (
+                result["coverage_summary"][name] for name in (
                     "real_checkpoint_or_algorithm",
                     "tiny_native_graph",
                     "external_checkpoint_blocker",
@@ -106,10 +95,8 @@ class ASRVADBenchmarkScriptTests(unittest.TestCase):
             34,
         )
         sherpa = next(
-            measurement
-            for measurement in result["vad_measurements"]
-            if measurement["model_type"] == "vad_sherpa_onnx"
-        )
+            measurement for measurement in result["vad_measurements"]
+            if measurement["model_type"] == "vad_sherpa_onnx")
         self.assertEqual(
             sherpa["profiles"][0]["mean_seconds"],
             1.6402040142255525,
@@ -158,12 +145,7 @@ class ASRVADBenchmarkScriptTests(unittest.TestCase):
         self.assertEqual(
             module._resolved_checkpoint_revision(
                 SimpleNamespace(
-                    model=SimpleNamespace(
-                        artifacts=SimpleNamespace(
-                            revision="commit-123",
-                        ),
-                    ),
-                ),
+                    model=SimpleNamespace(artifacts=SimpleNamespace(revision="commit-123", ), ), ),
                 SimpleNamespace(metadata={}),
             ),
             "commit-123",
@@ -171,9 +153,7 @@ class ASRVADBenchmarkScriptTests(unittest.TestCase):
         self.assertEqual(
             module._resolved_checkpoint_revision(
                 SimpleNamespace(),
-                SimpleNamespace(
-                    metadata={"checkpoint_revision": "main"},
-                ),
+                SimpleNamespace(metadata={"checkpoint_revision": "main"}, ),
             ),
             "main",
         )
@@ -190,8 +170,7 @@ class ASRVADBenchmarkScriptTests(unittest.TestCase):
                 output.setnchannels(1)
                 output.setsampwidth(2)
                 output.setframerate(16_000)
-                output.writeframes(
-                    struct.pack("<16000h", *([0] * 16_000)))
+                output.writeframes(struct.pack("<16000h", *([0] * 16_000)))
 
             completed = subprocess.run(
                 [

--- a/tests/test_auto_config_kwargs.py
+++ b/tests/test_auto_config_kwargs.py
@@ -2,11 +2,7 @@ from __future__ import annotations
 
 import unittest
 
-from voicehub.auto import (
-    AutoModelForSpeechRecognition,
-    AutoModelForTextToSpeech,
-    AutoModelForVoiceActivityDetection,
-)
+from voicehub.auto import AutoModelForSpeechRecognition, AutoModelForTextToSpeech, AutoModelForVoiceActivityDetection
 
 
 class AutoModelConfigKwargsTests(unittest.TestCase):

--- a/tests/test_distribution_compliance.py
+++ b/tests/test_distribution_compliance.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = PROJECT_ROOT / "scripts" / "check_distribution.py"
+
+
+class DistributionComplianceTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        spec = spec_from_file_location("voicehub_distribution_check_test_module", SCRIPT)
+        if spec is None or spec.loader is None:
+            raise RuntimeError("Could not import the distribution check script.")
+        cls.distribution = module_from_spec(spec)
+        spec.loader.exec_module(cls.distribution)
+
+    def test_every_source_manifest_is_pinned_and_licensed(self):
+        manifests = tuple(sorted((PROJECT_ROOT / "voicehub").rglob("SOURCE.json")))
+
+        self.assertGreater(len(manifests), 0)
+        self.assertEqual(
+            self.distribution.validate_provenance_manifests(PROJECT_ROOT),
+            len(manifests),
+        )
+
+    def test_compliance_inventory_covers_manifests_licenses_and_notices(self):
+        files = set(self.distribution.compliance_package_files(PROJECT_ROOT))
+
+        self.assertIn("voicehub/architectures/bark/SOURCE.json", files)
+        self.assertIn("voicehub/architectures/bark/THIRD_PARTY_LICENSE", files)
+        self.assertIn("voicehub/architectures/medasr/MODEL_TERMS_NOTICE", files)
+        self.assertIn("voicehub/architectures/vibevoice/source/THIRD_PARTY_NOTICES.md", files)
+        self.assertEqual(
+            {path
+             for path in files if path.endswith("SOURCE.json")},
+            {
+                path.relative_to(PROJECT_ROOT).as_posix()
+                for path in (PROJECT_ROOT / "voicehub").rglob("SOURCE.json")
+            },
+        )
+
+    def test_manifest_validation_rejects_missing_license_terms(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = root / "voicehub" / "models" / "example" / "SOURCE.json"
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(
+                json.dumps({
+                    "upstream": "https://example.invalid",
+                    "revision": "abc123"
+                }),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "does not record license terms"):
+                self.distribution.validate_provenance_manifests(root)
+
+    def test_archive_contract_requires_project_license(self):
+        self.distribution.require_project_license(
+            "wheel",
+            {"voicehub-0.3.0.dist-info/licenses/LICENSE"},
+        )
+        self.distribution.require_project_license("sdist", {"LICENSE"})
+
+        with self.assertRaisesRegex(RuntimeError, "project LICENSE"):
+            self.distribution.require_project_license("wheel", set())
+        with self.assertRaisesRegex(RuntimeError, "project LICENSE"):
+            self.distribution.require_project_license("sdist", set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_documentation_site.py
+++ b/tests/test_documentation_site.py
@@ -83,6 +83,8 @@ NAVIGATION_PATHS = (
     "project/adding-a-model.md",
     "project/adding-speech-provider.md",
     "project/adding-an-optimization.md",
+    "project/roadmap.md",
+    "project/release-readiness.md",
     "project/translations.md",
     "project/model-audit.md",
 )
@@ -261,6 +263,17 @@ class DocumentationSiteTests(unittest.TestCase):
                 self.assertIn("## Training", source)
                 self.assertIn(spec.task.value.replace("-", " "), source.lower())
                 self.assertIn(spec.training.support.value, source)
+                self.assertIn("| License |", source)
+                if spec.license is None:
+                    self.assertIn("| License | Checkpoint-specific |", source)
+                    self.assertIn(
+                        "Verify the checkpoint and upstream source terms before use.",
+                        source,
+                    )
+                else:
+                    self.assertIn(spec.license.license_id, source)
+                    self.assertIn(spec.license.upstream, source)
+                    self.assertIn(spec.license.notice, source)
                 self.assertIn(f"[`{spec.model_type}`]({path.name})", index)
                 self.assertEqual(
                     config.count(f"models/providers/{path.name}"),

--- a/tests/test_inference_contracts.py
+++ b/tests/test_inference_contracts.py
@@ -323,8 +323,8 @@ class InferenceLifecycleTests(unittest.TestCase):
         model = FlakyPrepareModel()
 
         with self.assertRaisesRegex(
-            RuntimeError,
-            "transient preparation failure",
+                RuntimeError,
+                "transient preparation failure",
         ):
             model.generate("first attempt")
         self.assertIsNone(model.model)

--- a/tests/test_inference_strategy.py
+++ b/tests/test_inference_strategy.py
@@ -16,10 +16,7 @@ from voicehub.inference_strategy import (
 )
 from voicehub.optimization import OptimizationCompatibilityError
 from voicehub.optimization.protocols import OptimizationCompileTarget
-from voicehub.optimization.torch_compile import (
-    TorchCompileCapabilityReport,
-    TorchCompileUnavailableError,
-)
+from voicehub.optimization.torch_compile import TorchCompileCapabilityReport, TorchCompileUnavailableError
 
 
 class RecordingInferenceStrategy(InferenceStrategy):
@@ -86,12 +83,11 @@ class InferenceStrategyHooksTest(unittest.TestCase):
 
             def optimization_compile_targets(self, mode):
                 self.compile_mode = mode
-                return (
-                    OptimizationCompileTarget(
-                        label="runtime",
-                        owner=self,
-                        attribute="forward",
-                    ), )
+                return (OptimizationCompileTarget(
+                    label="runtime",
+                    owner=self,
+                    attribute="forward",
+                ), )
 
         runtime = Runtime().eval()
         wrapper = SimpleNamespace(device="cpu")
@@ -139,14 +135,14 @@ class InferenceStrategyHooksTest(unittest.TestCase):
         )
 
         with (
-            patch(
-                "voicehub.optimization.torch_compile.inspect_torch_compile",
-                return_value=report,
-            ),
-            self.assertRaisesRegex(
-                TorchCompileUnavailableError,
-                "unit-test backend is unavailable",
-            ),
+                patch(
+                    "voicehub.optimization.torch_compile.inspect_torch_compile",
+                    return_value=report,
+                ),
+                self.assertRaisesRegex(
+                    TorchCompileUnavailableError,
+                    "unit-test backend is unavailable",
+                ),
         ):
             strategy.validate(SimpleNamespace(device="cpu"))
 
@@ -164,8 +160,8 @@ class InferenceStrategyHooksTest(unittest.TestCase):
                     ),
                 )
                 with self.assertRaisesRegex(
-                    OptimizationCompatibilityError,
-                    rf"{model_type}.*real-checkpoint",
+                        OptimizationCompatibilityError,
+                        rf"{model_type}.*real-checkpoint",
                 ):
                     model.load()
                 self.assertIsNone(model.model)
@@ -199,8 +195,8 @@ class InferenceStrategyHooksTest(unittest.TestCase):
         )
 
         with patch(
-            "voicehub.optimization.torch_compile.inspect_torch_compile",
-            return_value=report,
+                "voicehub.optimization.torch_compile.inspect_torch_compile",
+                return_value=report,
         ):
             strategy.validate(wrapper)
             prepared = strategy.prepare(runtime, wrapper=wrapper)

--- a/tests/test_native_f5tts_runtime.py
+++ b/tests/test_native_f5tts_runtime.py
@@ -30,10 +30,7 @@ from voicehub.architectures.f5tts.metadata import (
     VOCOS_SOURCE_REVISION,
 )
 from voicehub.architectures.f5tts.modeling import F5ConditionalFlowMatcher
-from voicehub.architectures.f5tts.modules import (
-    RotaryEmbedding,
-    apply_rotary_position_embedding,
-)
+from voicehub.architectures.f5tts.modules import RotaryEmbedding, apply_rotary_position_embedding
 from voicehub.architectures.f5tts.registration import create_f5tts_architecture_spec
 from voicehub.architectures.f5tts.runtime import NativeF5TTSRuntime
 from voicehub.architectures.f5tts.vocoder import ISTFTHead, NativeVocos
@@ -311,13 +308,11 @@ class NativeF5TTSRuntimeTests(unittest.TestCase):
         for flow_dtype in (torch.float16, torch.bfloat16):
             for vocoder_dtype in (torch.float32, flow_dtype):
                 with self.subTest(
-                    flow_dtype=flow_dtype,
-                    vocoder_dtype=vocoder_dtype,
+                        flow_dtype=flow_dtype,
+                        vocoder_dtype=vocoder_dtype,
                 ):
-                    flow = F5ConditionalFlowMatcher(_tiny_config()).to(
-                        dtype=flow_dtype)
-                    vocoder = TinyVocoder(flow.num_channels).to(
-                        dtype=vocoder_dtype)
+                    flow = F5ConditionalFlowMatcher(_tiny_config()).to(dtype=flow_dtype)
+                    vocoder = TinyVocoder(flow.num_channels).to(dtype=vocoder_dtype)
                     runtime = NativeF5TTSRuntime(
                         flow_model=flow,
                         vocoder=vocoder,
@@ -325,8 +320,8 @@ class NativeF5TTSRuntimeTests(unittest.TestCase):
                     )
 
                     with self.assertRaisesRegex(
-                        RuntimeError,
-                        "reduced-precision inference is disabled.*DiT",
+                            RuntimeError,
+                            "reduced-precision inference is disabled.*DiT",
                     ):
                         runtime.prepare_for_inference()
 
@@ -362,12 +357,10 @@ class NativeF5TTSRuntimeTests(unittest.TestCase):
 
     def test_reduced_precision_acknowledgement_is_boolean(self):
         with self.assertRaisesRegex(
-            TypeError,
-            "allow_unvalidated_reduced_precision_inference.*boolean",
+                TypeError,
+                "allow_unvalidated_reduced_precision_inference.*boolean",
         ):
-            F5TTSConfig(
-                allow_unvalidated_reduced_precision_inference="yes",
-            )
+            F5TTSConfig(allow_unvalidated_reduced_precision_inference="yes", )
 
     def test_reduced_precision_fails_before_checkpoint_resolution(self):
         model = F5TTSForTextToSpeech(
@@ -377,17 +370,15 @@ class NativeF5TTSRuntimeTests(unittest.TestCase):
         )
 
         with (
-            patch(
-                "voicehub.models.f5tts.inference.resolve_f5tts_artifacts",
-            ) as resolver,
-            patch(
-                "voicehub.models.f5tts.inference.resolve_torch_dtype",
-                return_value=torch.float16,
-            ),
-            self.assertRaisesRegex(
-                RuntimeError,
-                "reduced-precision inference is disabled",
-            ),
+                patch("voicehub.models.f5tts.inference.resolve_f5tts_artifacts", ) as resolver,
+                patch(
+                    "voicehub.models.f5tts.inference.resolve_torch_dtype",
+                    return_value=torch.float16,
+                ),
+                self.assertRaisesRegex(
+                    RuntimeError,
+                    "reduced-precision inference is disabled",
+                ),
         ):
             model.load()
 

--- a/tests/test_native_moonshine_model.py
+++ b/tests/test_native_moonshine_model.py
@@ -182,12 +182,8 @@ class MoonshineModelTests(unittest.TestCase):
             )
 
     def test_compile_targets_match_generation_execution_boundaries(self):
-        inference_targets = self.model.optimization_compile_targets(
-            "inference",
-        )
-        training_targets = self.model.optimization_compile_targets(
-            "training",
-        )
+        inference_targets = self.model.optimization_compile_targets("inference", )
+        training_targets = self.model.optimization_compile_targets("training", )
 
         self.assertEqual(
             tuple(target.label for target in inference_targets),

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -83,10 +83,8 @@ REQUIRED_DISTRIBUTION_FILES = (
     "voicehub/py.typed",
     "voicehub/architectures/outetts/default_speaker.json",
     "voicehub/models/conversationtts/source/conversationtts/llama3_2/tokenizer.json",
-    (
-        "voicehub/models/chatterbox/source/perth/perth_net/pretrained/implicit/"
-        "perth_net_250000.pth.tar"
-    ),
+    ("voicehub/models/chatterbox/source/perth/perth_net/pretrained/implicit/"
+     "perth_net_250000.pth.tar"),
     "voicehub/kernels/csrc/activations.cpp",
 )
 
@@ -281,11 +279,18 @@ class PackagingMetadataTests(unittest.TestCase):
                 self.assertTrue((REPOSITORY_ROOT / relative_path).is_file())
 
     def test_distribution_check_covers_all_install_modes(self):
-        source = (REPOSITORY_ROOT / "scripts" / "check_distribution.py").read_text(
-            encoding="utf-8")
-        self.assertIn('"wheel": install_and_probe(', source)
-        self.assertIn('"sdist": install_and_probe(', source)
-        self.assertIn('"editable": install_and_probe(', source)
+        source = (REPOSITORY_ROOT / "scripts" / "check_distribution.py").read_text(encoding="utf-8")
+        install_modes = set()
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.Dict):
+                continue
+            for key, value in zip(node.keys, node.values):
+                if (isinstance(key, ast.Constant) and isinstance(key.value, str) and
+                        isinstance(value, ast.Call) and isinstance(value.func, ast.Name) and
+                        value.func.id == "install_and_probe"):
+                    install_modes.add(key.value)
+
+        self.assertEqual(install_modes, {"wheel", "sdist", "editable"})
 
 
 if __name__ == "__main__":

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import io
+import json
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = PROJECT_ROOT / "scripts" / "check_release.py"
+WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+PACKAGE_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "package_testing.yml"
+
+
+class ReleaseReadinessTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        spec = spec_from_file_location("voicehub_release_check_test_module", SCRIPT)
+        if spec is None or spec.loader is None:
+            raise RuntimeError("Could not import the release check script.")
+        cls.release = module_from_spec(spec)
+        spec.loader.exec_module(cls.release)
+
+    @staticmethod
+    def _write_distributions(dist_dir: Path, version: str) -> None:
+        metadata = f"Metadata-Version: 2.4\nName: voicehub\nVersion: {version}\n\n"
+        wheel = dist_dir / f"voicehub-{version}-py3-none-any.whl"
+        with ZipFile(wheel, "w", compression=ZIP_DEFLATED) as archive:
+            archive.writestr(f"voicehub-{version}.dist-info/METADATA", metadata)
+
+        sdist = dist_dir / f"voicehub-{version}.tar.gz"
+        encoded = metadata.encode("utf-8")
+        with tarfile.open(sdist, "w:gz") as archive:
+            member = tarfile.TarInfo(f"voicehub-{version}/PKG-INFO")
+            member.size = len(encoded)
+            archive.addfile(member, io.BytesIO(encoded))
+
+    def test_current_source_docs_and_evidence_share_one_version(self):
+        version = self.release.source_version(PROJECT_ROOT)
+
+        self.assertEqual(version, "0.3.0")
+        self.release.validate_source_metadata(version, PROJECT_ROOT)
+        self.release.validate_documentation_version(version, PROJECT_ROOT)
+        self.assertEqual(
+            self.release.validate_layered_evidence(PROJECT_ROOT),
+            {
+                "tts_providers": 34,
+                "asr_providers": 23,
+                "vad_providers": 11,
+                "documented_providers": 68,
+            },
+        )
+        self.assertEqual(
+            self.release.validate_benchmark_versions(version, PROJECT_ROOT),
+            5,
+        )
+
+    def test_layered_evidence_requires_explicit_external_blockers(self):
+        filenames = (
+            "tts_optimization_rtx4090_2026-07-31.json",
+            "asr_vad_rtx4090_2026-07-31.json",
+            "tts_vits_rtx4090_2026-07-31.json",
+            "tts_vui_rtx4090_rejected_2026-07-31.json",
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            benchmark_dir = root / "benchmarks"
+            benchmark_dir.mkdir()
+            for filename in filenames:
+                shutil.copy2(PROJECT_ROOT / "benchmarks" / filename, benchmark_dir / filename)
+            shutil.copytree(
+                PROJECT_ROOT / "docs" / "models" / "providers",
+                root / "docs" / "models" / "providers",
+            )
+            path = benchmark_dir / "asr_vad_rtx4090_2026-07-31.json"
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            blocker = next(
+                row for row in payload["coverage"] if row["verification"] == "external-checkpoint-blocker")
+            blocker.pop("blocker")
+            path.write_text(json.dumps(payload), encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                    self.release.ReleaseCheckError,
+                    "invalid verification rows",
+            ):
+                self.release.validate_layered_evidence(root)
+
+    def test_distribution_pair_embeds_the_candidate_version(self):
+        with tempfile.TemporaryDirectory() as directory:
+            dist_dir = Path(directory)
+            self._write_distributions(dist_dir, "0.3.0")
+
+            sizes = self.release.validate_distributions(dist_dir, "0.3.0")
+
+        self.assertEqual(
+            set(sizes),
+            {
+                "voicehub-0.3.0-py3-none-any.whl",
+                "voicehub-0.3.0.tar.gz",
+            },
+        )
+        self.assertTrue(all(size > 0 for size in sizes.values()))
+
+    def test_distribution_pair_rejects_an_unexpected_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            dist_dir = Path(directory)
+            self._write_distributions(dist_dir, "0.3.0")
+            (dist_dir / "unreviewed.bin").write_bytes(b"not a distribution")
+
+            with self.assertRaisesRegex(
+                    self.release.ReleaseCheckError,
+                    "only the expected wheel and sdist",
+            ):
+                self.release.validate_distributions(dist_dir, "0.3.0")
+
+    def test_pypi_candidate_must_be_newer_and_unpublished(self):
+        payload = {
+            "info": {
+                "version": "0.1.6"
+            },
+            "releases": {
+                "0.1.6": [{
+                    "filename": "voicehub-0.1.6.tar.gz"
+                }]
+            },
+        }
+
+        self.assertEqual(
+            self.release.validate_pypi_payload(payload, "0.3.0", "candidate"),
+            "0.1.6",
+        )
+        payload["releases"]["0.3.0"] = [{"filename": "voicehub-0.3.0.tar.gz"}]
+        with self.assertRaisesRegex(
+                self.release.ReleaseCheckError,
+                "already present on PyPI",
+        ):
+            self.release.validate_pypi_payload(payload, "0.3.0", "candidate")
+
+    def test_pypi_post_publish_requires_exact_external_parity(self):
+        payload = {
+            "info": {
+                "version": "0.3.0"
+            },
+            "releases": {
+                "0.3.0": [{
+                    "filename": "voicehub-0.3.0-py3-none-any.whl"
+                }]
+            },
+        }
+
+        self.assertEqual(
+            self.release.validate_pypi_payload(payload, "0.3.0", "published"),
+            "0.3.0",
+        )
+
+    def test_release_workflow_separates_verification_from_oidc_publish(self):
+        source = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("workflow_dispatch:", source)
+        self.assertIn("confirm_publish:", source)
+        self.assertIn("default: false", source)
+        self.assertIn("tagged-cross-platform-tests:", source)
+        self.assertIn(
+            "operating-system: [ubuntu-latest, windows-latest, macos-latest]",
+            source,
+        )
+        self.assertIn('python-version: ["3.10", "3.11", "3.12"]', source)
+        self.assertIn("needs: tagged-cross-platform-tests", source)
+        self.assertIn("--require-tag-at-head", source)
+        self.assertIn("--pypi-policy candidate", source)
+        self.assertIn("- tagged-cross-platform-tests\n      - verify-and-build", source)
+        self.assertIn("name: pypi", source)
+        self.assertIn("id-token: write", source)
+        self.assertIn(
+            "pypa/gh-action-pypi-publish@"
+            "ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0",
+            source,
+        )
+        self.assertNotIn("PYPI_API_TOKEN", source)
+        self.assertNotIn("password:", source)
+
+    def test_package_ci_runs_the_complete_distribution_contract(self):
+        source = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("python scripts/check_release.py --dist-dir dist", source)
+        self.assertIn("python scripts/check_distribution.py", source)
+        self.assertIn("Import every integration from the installed wheel", source)
+
+    def test_release_script_cli_report_is_json(self):
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            cwd=PROJECT_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        report = json.loads(completed.stdout)
+        self.assertEqual(report["version"], "0.3.0")
+        self.assertEqual(report["benchmark_files"], 5)
+        self.assertEqual(report["layered_evidence"]["documented_providers"], 68)
+        self.assertEqual(report["source_metadata"], "passed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_torch_compile_optimization.py
+++ b/tests/test_torch_compile_optimization.py
@@ -713,8 +713,7 @@ class TorchCompileOptimizationTests(unittest.TestCase):
                 "nfe_step": 1,
                 "cross_fade_duration": 0.0,
             }
-            expected_waveform, expected_rate, expected_spectrogram = (
-                runtime.infer(**inference_kwargs))
+            expected_waveform, expected_rate, expected_spectrogram = (runtime.infer(**inference_kwargs))
             result = OptimizationPassManager().apply(
                 runtime,
                 (TorchCompilePass(
@@ -728,8 +727,7 @@ class TorchCompileOptimizationTests(unittest.TestCase):
                     dtype="float32",
                 ),
             )
-            waveform, sample_rate, spectrogram = runtime.infer(
-                **inference_kwargs)
+            waveform, sample_rate, spectrogram = runtime.infer(**inference_kwargs)
 
         self.assertEqual(sample_rate, expected_rate)
         self.assertEqual(sample_rate, 24_000)
@@ -825,8 +823,7 @@ class TorchCompileOptimizationTests(unittest.TestCase):
                 ), ),
                 self._context("training", architecture="neutts"),
             )
-            actual = runtime.codec.decode_code(
-                runtime.backbone(runtime.backbone(torch.tensor(3.0))))
+            actual = runtime.codec.decode_code(runtime.backbone(runtime.backbone(torch.tensor(3.0))))
 
         torch.testing.assert_close(actual, torch.tensor(13.0))
         self.assertEqual(compile_calls, ["forward", "forward"])

--- a/tests/test_tts_optimization_report.py
+++ b/tests/test_tts_optimization_report.py
@@ -11,11 +11,7 @@ from voicehub.registry import list_model_specs
 from voicehub.tasks import SpeechTask
 
 PROJECT_ROOT = Path(__file__).parents[1]
-ARTIFACT = (
-    PROJECT_ROOT
-    / "benchmarks"
-    / "tts_optimization_rtx4090_2026-07-31.json"
-)
+ARTIFACT = (PROJECT_ROOT / "benchmarks" / "tts_optimization_rtx4090_2026-07-31.json")
 GUIDE = PROJECT_ROOT / "docs" / "guides" / "tts-model-benchmarks.md"
 README = PROJECT_ROOT / "README.md"
 MKDOCS = PROJECT_ROOT / "mkdocs.yml"
@@ -73,7 +69,8 @@ class TTSOptimizationReportTests(unittest.TestCase):
             [spec.model_type for spec in specs],
         )
         self.assertEqual(
-            len({provider["model_type"] for provider in providers}),
+            len({provider["model_type"]
+                 for provider in providers}),
             34,
         )
         for provider, spec in zip(providers, specs, strict=True):
@@ -115,8 +112,7 @@ class TTSOptimizationReportTests(unittest.TestCase):
 
         no_checkpoint_revision = {
             provider["model_type"]
-            for provider in providers
-            if provider["checkpoint_revision"] is None
+            for provider in providers if provider["checkpoint_revision"] is None
         }
         self.assertEqual(
             no_checkpoint_revision,
@@ -127,40 +123,28 @@ class TTSOptimizationReportTests(unittest.TestCase):
         summary = self.result["summary"]
         providers = self.result["providers"]
         candidates = [
-            candidate
-            for model in self.result["real_checkpoint_results"]
-            for candidate in model["candidates"]
+            candidate for model in self.result["real_checkpoint_results"] for candidate in model["candidates"]
         ]
 
         self.assertEqual(summary["registered_tts_providers"], 34)
         self.assertEqual(summary["provider_rows"], len(providers))
         self.assertEqual(
             summary["highest_evidence_tier_counts"],
-            dict(Counter(
-                provider["highest_evidence_tier"]
-                for provider in providers
-            )),
+            dict(Counter(provider["highest_evidence_tier"] for provider in providers)),
         )
         self.assertEqual(
             summary["real_checkpoint_status_counts"],
-            dict(Counter(
-                provider["real_checkpoint_status"]
-                for provider in providers
-            )),
+            dict(Counter(provider["real_checkpoint_status"] for provider in providers)),
         )
         self.assertEqual(
             summary["measured_candidate_decision_counts"],
-            dict(Counter(
-                candidate["decision"]
-                for candidate in candidates
-            )),
+            dict(Counter(candidate["decision"] for candidate in candidates)),
         )
         self.assertEqual(
             set(summary["models_with_real_checkpoint_measurements"]),
             {
                 provider["model_type"]
-                for provider in providers
-                if provider["real_checkpoint_status"] == "measured"
+                for provider in providers if provider["real_checkpoint_status"] == "measured"
             },
         )
         self.assertEqual(
@@ -172,12 +156,12 @@ class TTSOptimizationReportTests(unittest.TestCase):
         results = self.result["real_checkpoint_results"]
         measured = {
             provider["model_type"]
-            for provider in self.result["providers"]
-            if provider["real_checkpoint_status"] == "measured"
+            for provider in self.result["providers"] if provider["real_checkpoint_status"] == "measured"
         }
 
         self.assertEqual(
-            {result["model_type"] for result in results},
+            {result["model_type"]
+             for result in results},
             measured,
         )
         all_candidates = []
@@ -195,10 +179,7 @@ class TTSOptimizationReportTests(unittest.TestCase):
                 self.assertGreaterEqual(reference["measured_runs"], 3)
                 self._assert_metrics(reference["metrics"])
 
-            profile_names = [
-                candidate["profile"]
-                for candidate in result["candidates"]
-            ]
+            profile_names = [candidate["profile"] for candidate in result["candidates"]]
             self.assertEqual(len(profile_names), len(set(profile_names)))
             for candidate in result["candidates"]:
                 all_candidates.append(candidate)
@@ -216,27 +197,16 @@ class TTSOptimizationReportTests(unittest.TestCase):
                 self.assertEqual(candidate["execution_status"], "ok")
                 metrics = candidate["metrics"]
                 self._assert_metrics(metrics)
-                reference = references[
-                    candidate["reference"]
-                ]["metrics"]
+                reference = references[candidate["reference"]]["metrics"]
                 comparison = candidate["comparison"]
                 self.assertAlmostEqual(
                     comparison["mean_speedup_ratio"],
-                    (
-                        reference["steady_mean_latency_seconds"]
-                        / metrics["steady_mean_latency_seconds"]
-                    ),
+                    (reference["steady_mean_latency_seconds"] / metrics["steady_mean_latency_seconds"]),
                 )
                 self.assertAlmostEqual(
                     comparison["latency_reduction_percent"],
-                    (
-                        (
-                            reference["steady_mean_latency_seconds"]
-                            - metrics["steady_mean_latency_seconds"]
-                        )
-                        / reference["steady_mean_latency_seconds"]
-                        * 100.0
-                    ),
+                    ((reference["steady_mean_latency_seconds"] - metrics["steady_mean_latency_seconds"]) /
+                     reference["steady_mean_latency_seconds"] * 100.0),
                 )
                 for metric_name, comparison_name in (
                     (
@@ -252,14 +222,7 @@ class TTSOptimizationReportTests(unittest.TestCase):
                         continue
                     self.assertAlmostEqual(
                         comparison[comparison_name],
-                        (
-                            (
-                                reference[metric_name]
-                                - metrics[metric_name]
-                            )
-                            / reference[metric_name]
-                            * 100.0
-                        ),
+                        ((reference[metric_name] - metrics[metric_name]) / reference[metric_name] * 100.0),
                     )
 
                 if candidate["decision"] == "accepted":
@@ -274,12 +237,9 @@ class TTSOptimizationReportTests(unittest.TestCase):
                     self.assertTrue(candidate["quality_passed"])
 
         self.assertEqual(
-            {
-                (result["model_type"], candidate["profile"])
-                for result in results
-                for candidate in result["candidates"]
-                if candidate["decision"] == "accepted"
-            },
+            {(result["model_type"], candidate["profile"])
+             for result in results
+             for candidate in result["candidates"] if candidate["decision"] == "accepted"},
             {
                 ("f5tts", "compile-regional"),
                 ("vits", "weight-norm-cache"),
@@ -291,14 +251,13 @@ class TTSOptimizationReportTests(unittest.TestCase):
         checked = self.result["source_reports"]
         self.assertEqual(len(checked), 3)
         self.assertEqual(
-            {report["name"] for report in checked},
+            {report["name"]
+             for report in checked},
             {
                 "tts_vits_rtx4090_2026-07-31.json",
                 "tts_vui_rtx4090_rejected_2026-07-31.json",
-                (
-                    "tts_optimization_rtx4090_raw_evidence_"
-                    "2026-07-31.json"
-                ),
+                ("tts_optimization_rtx4090_raw_evidence_"
+                 "2026-07-31.json"),
             },
         )
         for report in checked:
@@ -309,18 +268,12 @@ class TTSOptimizationReportTests(unittest.TestCase):
                 self.assertEqual(_sha256(path), report["sha256"])
 
     def test_raw_evidence_retains_every_normalized_measured_run(self):
-        raw_path = (
-            PROJECT_ROOT
-            / "benchmarks"
-            / "tts_optimization_rtx4090_raw_evidence_2026-07-31.json"
-        )
+        raw_path = (PROJECT_ROOT / "benchmarks" / "tts_optimization_rtx4090_raw_evidence_2026-07-31.json")
         raw = json.loads(
             raw_path.read_text(encoding="utf-8"),
             parse_constant=_reject_nonfinite_json,
         )
-        source_files = {
-            run["source_file"] for run in raw["benchmark_runs"]
-        }
+        source_files = {run["source_file"] for run in raw["benchmark_runs"]}
         self.assertEqual(
             source_files,
             {
@@ -337,56 +290,40 @@ class TTSOptimizationReportTests(unittest.TestCase):
         self.assertEqual(raw["registry_audit"]["provider_count"], 34)
         vui_artifacts = raw["verified_checkpoint_artifacts"]["vui"]
         self.assertEqual(
-            {artifact["sha256"] for artifact in vui_artifacts["artifacts"]},
+            {artifact["sha256"]
+             for artifact in vui_artifacts["artifacts"]},
             {
-                (
-                    "28353f13788c353160efbfc4fa5f5db56844746d3de9a925"
-                    "31dfee704cc394ff"
-                ),
-                (
-                    "04d1ee6567b5eaade6720bf7cc0241fbbd3c0aaeca00ac37"
-                    "cd1656afa08f3c96"
-                ),
+                ("28353f13788c353160efbfc4fa5f5db56844746d3de9a925"
+                 "31dfee704cc394ff"),
+                ("04d1ee6567b5eaade6720bf7cc0241fbbd3c0aaeca00ac37"
+                 "cd1656afa08f3c96"),
             },
         )
 
         profile_map = {
-            ("voicehub-vui-fixed-20260731.json", "baseline"):
-                ("vui", "reference", "dynamic-pair"),
-            ("voicehub-vui-fixed-20260731.json", "compile-dynamic"):
-                ("vui", "candidate", "compile-dynamic"),
-            ("voicehub-vui-specialized-20260731.json", "baseline"):
-                ("vui", "reference", "specialized-pair"),
+            ("voicehub-vui-fixed-20260731.json", "baseline"): ("vui", "reference", "dynamic-pair"),
+            ("voicehub-vui-fixed-20260731.json", "compile-dynamic"): ("vui", "candidate", "compile-dynamic"),
+            ("voicehub-vui-specialized-20260731.json", "baseline"): ("vui", "reference", "specialized-pair"),
             (
                 "voicehub-vui-specialized-20260731.json",
                 "compile-specialized",
             ): ("vui", "candidate", "compile-specialized"),
-            ("voicehub-f5-matrix-20260731.json", "baseline"):
-                ("f5tts", "reference", "main"),
-            ("voicehub-f5-matrix-20260731.json", "bf16"):
-                ("f5tts", "candidate", "bfloat16"),
-            ("voicehub-f5-matrix-20260731.json", "sdpa"):
-                ("f5tts", "candidate", "sdpa"),
-            ("voicehub-f5-matrix-20260731.json", "triton"):
-                ("f5tts", "candidate", "triton"),
-            ("voicehub-f5-matrix-20260731.json", "sdpa-triton"):
-                ("f5tts", "candidate", "sdpa-triton"),
-            ("voicehub-f5-matrix-20260731.json", "nfe-16"):
-                ("f5tts", "candidate", "nfe-16"),
-            ("voicehub-f5-matrix-20260731.json", "dbcache"):
-                ("f5tts", "candidate", "dbcache-0.05"),
-            ("voicehub-f5-dbcache012-20260731.json", "dbcache-0.12"):
-                ("f5tts", "candidate", "dbcache-0.12"),
+            ("voicehub-f5-matrix-20260731.json", "baseline"): ("f5tts", "reference", "main"),
+            ("voicehub-f5-matrix-20260731.json", "bf16"): ("f5tts", "candidate", "bfloat16"),
+            ("voicehub-f5-matrix-20260731.json", "sdpa"): ("f5tts", "candidate", "sdpa"),
+            ("voicehub-f5-matrix-20260731.json", "triton"): ("f5tts", "candidate", "triton"),
+            ("voicehub-f5-matrix-20260731.json", "sdpa-triton"): ("f5tts", "candidate", "sdpa-triton"),
+            ("voicehub-f5-matrix-20260731.json", "nfe-16"): ("f5tts", "candidate", "nfe-16"),
+            ("voicehub-f5-matrix-20260731.json", "dbcache"): ("f5tts", "candidate", "dbcache-0.05"),
+            ("voicehub-f5-dbcache012-20260731.json", "dbcache-0.12"): ("f5tts", "candidate", "dbcache-0.12"),
             ("voicehub-f5-compile-regional-20260731.json", "baseline"):
-                ("f5tts", "reference", "compile-pair"),
+            ("f5tts", "reference", "compile-pair"),
             (
                 "voicehub-f5-compile-regional-20260731.json",
                 "compile-regional",
             ): ("f5tts", "candidate", "compile-regional"),
-            ("voicehub-neutts-sdpa-20260731.json", "baseline"):
-                ("neutts", "reference", "main"),
-            ("voicehub-neutts-sdpa-20260731.json", "sdpa"):
-                ("neutts", "candidate", "sdpa"),
+            ("voicehub-neutts-sdpa-20260731.json", "baseline"): ("neutts", "reference", "main"),
+            ("voicehub-neutts-sdpa-20260731.json", "sdpa"): ("neutts", "candidate", "sdpa"),
             (
                 "voicehub-neutts-compile-regional-20260731.json",
                 "baseline",
@@ -395,26 +332,16 @@ class TTSOptimizationReportTests(unittest.TestCase):
                 "voicehub-neutts-compile-regional-20260731.json",
                 "compile-regional",
             ): ("neutts", "candidate", "compile-regional"),
-            ("voicehub-supertonic-matrix-20260731.json", "baseline"):
-                ("supertonic", "reference", "main"),
-            ("voicehub-supertonic-matrix-20260731.json", "compile"):
-                ("supertonic", "candidate", "compile"),
-            ("voicehub-supertonic-matrix-20260731.json", "steps-3"):
-                ("supertonic", "candidate", "steps-3"),
-            ("voicehub-supertonic-matrix-20260731.json", "steps-2"):
-                ("supertonic", "candidate", "steps-2"),
+            ("voicehub-supertonic-matrix-20260731.json", "baseline"): ("supertonic", "reference", "main"),
+            ("voicehub-supertonic-matrix-20260731.json", "compile"): ("supertonic", "candidate", "compile"),
+            ("voicehub-supertonic-matrix-20260731.json", "steps-3"): ("supertonic", "candidate", "steps-3"),
+            ("voicehub-supertonic-matrix-20260731.json", "steps-2"): ("supertonic", "candidate", "steps-2"),
         }
-        raw_profiles = {
-            (run["source_file"], profile["profile"]): profile
-            for run in raw["benchmark_runs"]
-            for profile in run["profiles"]
-            if profile["status"] == "ok"
-        }
+        raw_profiles = {(run["source_file"], profile["profile"]): profile
+                        for run in raw["benchmark_runs"]
+                        for profile in run["profiles"] if profile["status"] == "ok"}
         self.assertEqual(set(profile_map), set(raw_profiles))
-        models = {
-            result["model_type"]: result
-            for result in self.result["real_checkpoint_results"]
-        }
+        models = {result["model_type"]: result for result in self.result["real_checkpoint_results"]}
         for raw_key, normalized_key in profile_map.items():
             with self.subTest(source=raw_key[0], profile=raw_key[1]):
                 model_type, kind, name = normalized_key
@@ -423,10 +350,7 @@ class TTSOptimizationReportTests(unittest.TestCase):
                     normalized = model["references"][name]
                 else:
                     normalized = next(
-                        candidate
-                        for candidate in model["candidates"]
-                        if candidate["profile"] == name
-                    )
+                        candidate for candidate in model["candidates"] if candidate["profile"] == name)
                 profile = raw_profiles[raw_key]
                 cold = profile["cold"]
                 steady = profile["steady"]
@@ -434,14 +358,10 @@ class TTSOptimizationReportTests(unittest.TestCase):
                 expected_metrics = {
                     "audio_duration_seconds": cold["duration_seconds"],
                     "cold_latency_seconds": cold["latency_seconds"],
-                    "steady_mean_latency_seconds":
-                        steady["mean_latency_seconds"],
-                    "steady_median_latency_seconds":
-                        steady["median_latency_seconds"],
-                    "peak_allocated_bytes":
-                        steady["memory"]["peak_allocated_bytes"],
-                    "peak_reserved_bytes":
-                        steady["memory"]["peak_reserved_bytes"],
+                    "steady_mean_latency_seconds": steady["mean_latency_seconds"],
+                    "steady_median_latency_seconds": steady["median_latency_seconds"],
+                    "peak_allocated_bytes": steady["memory"]["peak_allocated_bytes"],
+                    "peak_reserved_bytes": steady["memory"]["peak_reserved_bytes"],
                 }
                 self.assertEqual(metrics, expected_metrics)
                 self.assertAlmostEqual(
@@ -465,10 +385,7 @@ class TTSOptimizationReportTests(unittest.TestCase):
         for line in section.splitlines():
             if not line.startswith("| `"):
                 continue
-            columns = [
-                value.strip().strip("`")
-                for value in line.strip().strip("|").split("|")
-            ]
+            columns = [value.strip().strip("`") for value in line.strip().strip("|").split("|")]
             rows[columns[0]] = columns
 
         self.assertEqual(len(rows), 34)
@@ -513,21 +430,21 @@ class TTSOptimizationReportTests(unittest.TestCase):
             10.0,
         )
         for name in (
-            "audio_duration_seconds",
-            "steady_mean_latency_seconds",
+                "audio_duration_seconds",
+                "steady_mean_latency_seconds",
         ):
             self.assertTrue(math.isfinite(metrics[name]))
             self.assertGreater(metrics[name], 0)
         for name in (
-            "cold_latency_seconds",
-            "steady_median_latency_seconds",
+                "cold_latency_seconds",
+                "steady_median_latency_seconds",
         ):
             if metrics[name] is not None:
                 self.assertTrue(math.isfinite(metrics[name]))
                 self.assertGreater(metrics[name], 0)
         for name in (
-            "peak_allocated_bytes",
-            "peak_reserved_bytes",
+                "peak_allocated_bytes",
+                "peak_reserved_bytes",
         ):
             if metrics[name] is not None:
                 self.assertIsInstance(metrics[name], int)

--- a/tests/test_vad_inference_providers.py
+++ b/tests/test_vad_inference_providers.py
@@ -11,18 +11,9 @@ from unittest.mock import patch
 import numpy as np
 import torch
 
-from voicehub.models.vad_silero import (
-    SileroVADConfig,
-    SileroVADForVoiceActivityDetection,
-)
-from voicehub.models.vad_transformers import (
-    TransformersVADConfig,
-    TransformersVADForVoiceActivityDetection,
-)
-from voicehub.models.vad_webrtc import (
-    WebRTCVADConfig,
-    WebRTCVADForVoiceActivityDetection,
-)
+from voicehub.models.vad_silero import SileroVADConfig, SileroVADForVoiceActivityDetection
+from voicehub.models.vad_transformers import TransformersVADConfig, TransformersVADForVoiceActivityDetection
+from voicehub.models.vad_webrtc import WebRTCVADConfig, WebRTCVADForVoiceActivityDetection
 from voicehub.models.vad_webrtc.modeling_vad_webrtc import _pcm16_samples
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -251,9 +242,7 @@ class SileroVADInferenceTests(unittest.TestCase):
     def test_native_silero_maps_controls_and_returns_frame_scores(self):
         import torch
 
-        from voicehub.architectures.silero_vad.configuration import (
-            SileroVADConfig as NativeSileroVADConfig,
-        )
+        from voicehub.architectures.silero_vad.configuration import SileroVADConfig as NativeSileroVADConfig
 
         captured = {}
 
@@ -301,9 +290,7 @@ class SileroVADInferenceTests(unittest.TestCase):
     def test_native_silero_frame_scores_are_direct_model_probabilities(self):
         import torch
 
-        from voicehub.architectures.silero_vad.configuration import (
-            SileroVADConfig as NativeSileroVADConfig,
-        )
+        from voicehub.architectures.silero_vad.configuration import SileroVADConfig as NativeSileroVADConfig
 
         model = SileroVADForVoiceActivityDetection(
             SileroVADConfig(),

--- a/tests/test_vits_optimization_system.py
+++ b/tests/test_vits_optimization_system.py
@@ -330,12 +330,13 @@ class VITSStructuralKernelTests(unittest.TestCase):
         ):
             OptimizationPassManager().apply(
                 model,
-                (TorchCompilePass(
-                    backend="aot_eager",
-                    fullgraph=True,
-                    dynamic=True,
-                    requirement="required",
-                ), ),
+                (
+                    TorchCompilePass(
+                        backend="aot_eager",
+                        fullgraph=True,
+                        dynamic=True,
+                        requirement="required",
+                    ), ),
                 context,
             )
         result = OptimizationPassManager().apply(

--- a/voicehub/architectures/f5tts/checkpoint.py
+++ b/voicehub/architectures/f5tts/checkpoint.py
@@ -11,10 +11,7 @@ from typing import Any
 import torch
 from torch import nn
 
-from voicehub.architectures.f5tts.metadata import (
-    F5TTS_NATIVE_FORMAT,
-    VOCOS_NATIVE_FORMAT,
-)
+from voicehub.architectures.f5tts.metadata import F5TTS_NATIVE_FORMAT, VOCOS_NATIVE_FORMAT
 from voicehub.checkpointing import SafeTensorReader, save_safetensors
 
 
@@ -72,8 +69,7 @@ def _resolve_prefix(
     for prefix in dict.fromkeys(candidates):
         names = {
             name.removeprefix(prefix)
-            for name in checkpoint_names
-            if not prefix or name.startswith(prefix)
+            for name in checkpoint_names if not prefix or name.startswith(prefix)
         }
         if set(expected).issubset(names):
             return prefix
@@ -118,11 +114,7 @@ def load_f5tts_checkpoint(
         selected = {f"{prefix}{name}" for name in expected}
         ignored = {"step", "initted"}
         checkpoint_names = reader.keys()
-        unexpected = tuple(
-            name
-            for name in checkpoint_names
-            if name not in selected and name not in ignored
-        )
+        unexpected = tuple(name for name in checkpoint_names if name not in selected and name not in ignored)
     if strict and (missing or unexpected):
         raise ValueError(
             "F5-TTS checkpoint namespace mismatch: "
@@ -258,9 +250,7 @@ def load_vocos_checkpoint(
     with SafeTensorReader(source) as reader:
         missing = tuple(name for name in expected if name not in reader)
         checkpoint_names = reader.keys()
-        unexpected = tuple(
-            name for name in checkpoint_names if name not in expected
-        )
+        unexpected = tuple(name for name in checkpoint_names if name not in expected)
         if missing or unexpected:
             raise ValueError(
                 "Vocos checkpoint namespace mismatch: "

--- a/voicehub/architectures/f5tts/registration.py
+++ b/voicehub/architectures/f5tts/registration.py
@@ -15,10 +15,7 @@ from voicehub.architectures.f5tts.metadata import (
     VOCOS_SOURCE_REVISION,
 )
 from voicehub.architectures.registry import ARCHITECTURE_REGISTRY, ArchitectureRegistry
-from voicehub.architectures.specifications import (
-    ArchitectureCapabilities,
-    ArchitectureSpec,
-)
+from voicehub.architectures.specifications import ArchitectureCapabilities, ArchitectureSpec
 from voicehub.tasks import SpeechTask
 
 DEFAULT_F5TTS_ALIASES = (
@@ -133,14 +130,11 @@ def create_f5tts_architecture_spec() -> ArchitectureSpec:
                 "Vocos remains frozen during flow fine-tuning."),
             "full_finetuning_ready":
             True,
-            "quality_validated_inference_dtypes": (
-                "float32",
-            ),
+            "quality_validated_inference_dtypes": ("float32", ),
             "reduced_precision_inference_policy": (
                 "Explicit opt-in is required because whole-model BF16 and "
                 "mixed DiT-BF16 inference failed the end-to-end quality "
-                "gate; FP16 has no retained quality validation."
-            ),
+                "gate; FP16 has no retained quality validation."),
         },
     )
 

--- a/voicehub/architectures/f5tts/runtime.py
+++ b/voicehub/architectures/f5tts/runtime.py
@@ -10,18 +10,11 @@ from pathlib import Path
 import torch
 from torch import nn
 
-from voicehub.architectures.f5tts.audio import (
-    cross_fade,
-    normalize_reference_rms,
-    trim_silence,
-)
+from voicehub.architectures.f5tts.audio import cross_fade, normalize_reference_rms, trim_silence
 from voicehub.architectures.f5tts.frontend import NativeF5TextFrontend, TokenSequence
 from voicehub.architectures.f5tts.modeling import F5ConditionalFlowMatcher
 from voicehub.architectures.f5tts.vocoder import NativeVocos
-from voicehub.optimization.protocols import (
-    OptimizationCompileTarget,
-    OptimizationModuleRoot,
-)
+from voicehub.optimization.protocols import OptimizationCompileTarget, OptimizationModuleRoot
 from voicehub.processing.waveform import load_native_audio
 
 _SENTENCE_BOUNDARY = re.compile(r"(?<=[;:,.!?])\s+|(?<=[；：，。！？])")
@@ -77,14 +70,12 @@ class NativeF5TTSRuntime(nn.Module):
     ) -> None:
         super().__init__()
         if not isinstance(allow_unvalidated_reduced_precision_inference, bool):
-            raise TypeError(
-                "`allow_unvalidated_reduced_precision_inference` must be a "
-                "boolean.")
+            raise TypeError("`allow_unvalidated_reduced_precision_inference` must be a "
+                            "boolean.")
         self.ema_model = flow_model
         self.vocoder = vocoder
         self.frontend = frontend
-        self.allow_unvalidated_reduced_precision_inference = (
-            allow_unvalidated_reduced_precision_inference)
+        self.allow_unvalidated_reduced_precision_inference = (allow_unvalidated_reduced_precision_inference)
         self.target_sample_rate = flow_model.config.sample_rate
         self.hop_length = flow_model.config.hop_length
         self.seed: int | None = None
@@ -122,11 +113,12 @@ class NativeF5TTSRuntime(nn.Module):
         # Keep dynamic duration, RNG, solver control flow, and the one-shot
         # vocoder eager. The DiT is the stable tensor region repeated at every
         # flow evaluation.
-        return (OptimizationCompileTarget(
-            "flow_model.transformer.forward",
-            self.ema_model.transformer,
-            "forward",
-        ), )
+        return (
+            OptimizationCompileTarget(
+                "flow_model.transformer.forward",
+                self.ema_model.transformer,
+                "forward",
+            ), )
 
     def prepare_for_training(self) -> None:
         self.ema_model.train()
@@ -145,32 +137,21 @@ class NativeF5TTSRuntime(nn.Module):
             "DiT": self.ema_model,
             "Vocos": self.vocoder,
         }
-        reduced_precision_components = tuple(
-            (
-                name,
-                tuple(sorted({
+        reduced_precision_components = tuple((
+            name,
+            tuple(
+                sorted({
                     str(parameter.dtype).removeprefix("torch.")
                     for parameter in component.parameters()
-                    if (
-                        parameter.is_floating_point()
-                        and parameter.dtype != torch.float32
-                    )
+                    if (parameter.is_floating_point() and parameter.dtype != torch.float32)
                 })),
-            )
-            for name, component in components.items()
-            if component is not None
-            and any(
-                parameter.is_floating_point()
-                and parameter.dtype != torch.float32
-                for parameter in component.parameters()
-            )
-        )
+        ) for name, component in components.items() if component is not None and any(
+            parameter.is_floating_point() and parameter.dtype != torch.float32
+            for parameter in component.parameters()))
         if not reduced_precision_components:
             return
         joined = " and ".join(
-            f"{name} ({', '.join(dtypes)})"
-            for name, dtypes in reduced_precision_components
-        )
+            f"{name} ({', '.join(dtypes)})" for name, dtypes in reduced_precision_components)
         raise RuntimeError(
             "F5-TTS reduced-precision inference is disabled by default "
             "because the "

--- a/voicehub/architectures/moonshine/registration.py
+++ b/voicehub/architectures/moonshine/registration.py
@@ -4,18 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
-from voicehub.architectures.moonshine.checkpoint import (
-    USEFULSENSORS_MOONSHINE_TINY_REVISION,
-)
+from voicehub.architectures.moonshine.checkpoint import USEFULSENSORS_MOONSHINE_TINY_REVISION
 from voicehub.architectures.moonshine.configuration import (
     MOONSHINE_MAIN_LIBRARY_REVISION,
     TRANSFORMERS_MOONSHINE_REVISION,
 )
 from voicehub.architectures.registry import ARCHITECTURE_REGISTRY, ArchitectureRegistry
-from voicehub.architectures.specifications import (
-    ArchitectureCapabilities,
-    ArchitectureSpec,
-)
+from voicehub.architectures.specifications import ArchitectureCapabilities, ArchitectureSpec
 from voicehub.tasks import SpeechTask
 
 DEFAULT_MOONSHINE_ALIASES = (

--- a/voicehub/architectures/neutts/modeling.py
+++ b/voicehub/architectures/neutts/modeling.py
@@ -25,11 +25,7 @@ from voicehub.architectures.neutts.tokenization import (
     normalize_neutts_text,
 )
 from voicehub.generation import GenerationConfig
-from voicehub.generation.engine import (
-    AutoregressiveGenerator,
-    GenerationStepInput,
-    GenerationStepOutput,
-)
+from voicehub.generation.engine import AutoregressiveGenerator, GenerationStepInput, GenerationStepOutput
 from voicehub.neural.rotary import RotaryEmbedding
 from voicehub.optimization.protocols import OptimizationCompileTarget
 from voicehub.processing.waveform import load_native_audio
@@ -190,8 +186,9 @@ class NeuTTSRuntime(nn.Module):
 
         Real-checkpoint inference validation changed generated audio and
         transcript content after compiling the autoregressive backbone.
-        Training keeps the full-sequence backbone boundary because it does
-        not perform stochastic token generation or waveform reconstruction.
+        Training keeps the full-sequence backbone boundary because it
+        does not perform stochastic token generation or waveform
+        reconstruction.
         """
         if mode == "inference":
             return ()

--- a/voicehub/architectures/neutts/registration.py
+++ b/voicehub/architectures/neutts/registration.py
@@ -12,10 +12,7 @@ from voicehub.architectures.neutts.metadata import (
     NEUTTS_VARIANTS,
 )
 from voicehub.architectures.registry import ARCHITECTURE_REGISTRY, ArchitectureRegistry
-from voicehub.architectures.specifications import (
-    ArchitectureCapabilities,
-    ArchitectureSpec,
-)
+from voicehub.architectures.specifications import ArchitectureCapabilities, ArchitectureSpec
 from voicehub.tasks import SpeechTask
 
 DEFAULT_NEUTTS_ALIASES = (

--- a/voicehub/architectures/vits/modeling.py
+++ b/voicehub/architectures/vits/modeling.py
@@ -18,11 +18,7 @@ import torch
 from torch import Tensor, nn
 from torch.nn import functional
 
-from voicehub.architectures.vits.alignment import (
-    generate_path,
-    maximum_path,
-    sequence_mask,
-)
+from voicehub.architectures.vits.alignment import generate_path, maximum_path, sequence_mask
 from voicehub.architectures.vits.configuration import VitsConfig
 from voicehub.kernels.vits import VITSKernelOptimizable
 from voicehub.optimization.protocols import OptimizationCompileTarget

--- a/voicehub/architectures/vits/registration.py
+++ b/voicehub/architectures/vits/registration.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 from voicehub.architectures.registry import ARCHITECTURE_REGISTRY, ArchitectureRegistry
-from voicehub.architectures.specifications import (
-    ArchitectureCapabilities,
-    ArchitectureSpec,
-)
+from voicehub.architectures.specifications import ArchitectureCapabilities, ArchitectureSpec
 from voicehub.architectures.vits.checkpoint import (
     FACEBOOK_MMS_TTS_ENG_REVISION,
     ORIGINAL_VITS_REVISION,

--- a/voicehub/architectures/vui/registration.py
+++ b/voicehub/architectures/vui/registration.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 from voicehub.architectures.registry import ARCHITECTURE_REGISTRY, ArchitectureRegistry
-from voicehub.architectures.specifications import (
-    ArchitectureCapabilities,
-    ArchitectureSpec,
-)
+from voicehub.architectures.specifications import ArchitectureCapabilities, ArchitectureSpec
 from voicehub.tasks import SpeechTask
 
 DEFAULT_VUI_ALIASES = (

--- a/voicehub/inference_strategy.py
+++ b/voicehub/inference_strategy.py
@@ -99,36 +99,25 @@ class TorchCompileInferenceStrategy(InferenceStrategy):
         )
 
         context = self._runtime_context(None, wrapper)
-        architecture = (
-            None
-            if context.architecture is None else
-            get_architecture_spec(context.architecture)
-        )
+        architecture = (None if context.architecture is None else get_architecture_spec(context.architecture))
         architecture_issue = torch_compile_architecture_incompatibility(
             self.config,
             architecture,
             mode=context.mode,
         )
-        if (
-                architecture_issue is not None
-                and self.config.requirement is TorchCompileRequirement.REQUIRED
-        ):
+        if (architecture_issue is not None and self.config.requirement is TorchCompileRequirement.REQUIRED):
             raise OptimizationCompatibilityError(architecture_issue)
 
         report = inspect_torch_compile(self.config.backend)
-        if (
-            not report.available
-            and self.config.requirement is TorchCompileRequirement.REQUIRED
-        ):
+        if (not report.available and self.config.requirement is TorchCompileRequirement.REQUIRED):
             raise TorchCompileUnavailableError(
                 "Required torch.compile inference is unavailable: "
                 f"{report.reason or 'unknown compiler error'}")
 
         requested_device = str(getattr(wrapper, "device", "cpu")).partition(":")[0]
         if requested_device == "mps":
-            raise ValueError(
-                "TorchCompileInferenceStrategy supports CPU and CUDA runtimes, "
-                "not MPS.")
+            raise ValueError("TorchCompileInferenceStrategy supports CPU and CUDA runtimes, "
+                             "not MPS.")
 
     @staticmethod
     def _runtime_context(model: Any, wrapper: Any):
@@ -218,9 +207,7 @@ _BUILTIN_INFERENCE_STRATEGIES: dict[str, InferenceStrategyFactory] = {
     _BUILTIN_STRATEGY_NAME: EagerInferenceStrategy,
     TorchCompileInferenceStrategy.name: TorchCompileInferenceStrategy,
 }
-_INFERENCE_STRATEGIES: dict[str, InferenceStrategyFactory] = dict(
-    _BUILTIN_INFERENCE_STRATEGIES,
-)
+_INFERENCE_STRATEGIES: dict[str, InferenceStrategyFactory] = dict(_BUILTIN_INFERENCE_STRATEGIES, )
 _REGISTRY_LOCK = RLock()
 
 
@@ -244,7 +231,8 @@ def register_inference_strategy(
     Factories are called only when :func:`get_inference_strategy`
     resolves the strategy, allowing implementations to import optional
     runtimes lazily. ``exist_ok=True`` intentionally replaces an
-    existing custom registration. Built-in strategies cannot be replaced.
+    existing custom registration. Built-in strategies cannot be
+    replaced.
     """
     normalized = _normalize_strategy_name(name)
     if not callable(factory):
@@ -256,8 +244,7 @@ def register_inference_strategy(
         if normalized in _BUILTIN_INFERENCE_STRATEGIES:
             if exist_ok and factory is _BUILTIN_INFERENCE_STRATEGIES[normalized]:
                 return
-            raise ValueError(
-                f"The built-in {normalized!r} strategy cannot be replaced.")
+            raise ValueError(f"The built-in {normalized!r} strategy cannot be replaced.")
         if normalized in _INFERENCE_STRATEGIES and not exist_ok:
             raise ValueError(f"An inference strategy named {normalized!r} is already registered.")
         _INFERENCE_STRATEGIES[normalized] = factory
@@ -270,8 +257,7 @@ def unregister_inference_strategy(name: str) -> None:
     """
     normalized = _normalize_strategy_name(name)
     if normalized in _BUILTIN_INFERENCE_STRATEGIES:
-        raise ValueError(
-            f"The built-in {normalized!r} strategy cannot be unregistered.")
+        raise ValueError(f"The built-in {normalized!r} strategy cannot be unregistered.")
 
     with _REGISTRY_LOCK:
         try:

--- a/voicehub/models/f5tts/inference.py
+++ b/voicehub/models/f5tts/inference.py
@@ -10,14 +10,8 @@ from typing import Any
 import torch
 
 from voicehub.architectures.f5tts.artifacts import resolve_f5tts_artifacts
-from voicehub.architectures.f5tts.checkpoint import (
-    load_f5tts_checkpoint,
-    load_vocos_checkpoint,
-)
-from voicehub.architectures.f5tts.configuration import (
-    F5TTSArchitectureConfig,
-    f5tts_architecture_config,
-)
+from voicehub.architectures.f5tts.checkpoint import load_f5tts_checkpoint, load_vocos_checkpoint
+from voicehub.architectures.f5tts.configuration import F5TTSArchitectureConfig, f5tts_architecture_config
 from voicehub.architectures.f5tts.frontend import F5Vocabulary, NativeF5TextFrontend
 from voicehub.architectures.f5tts.modeling import F5ConditionalFlowMatcher
 from voicehub.architectures.f5tts.runtime import NativeF5TTSRuntime
@@ -63,8 +57,7 @@ class F5TTSConfig(VoiceHubConfig):
         self.architecture = dict(architecture or {})
         self.ode_method = ode_method
         self.torch_dtype = torch_dtype
-        self.allow_unvalidated_reduced_precision_inference = (
-            allow_unvalidated_reduced_precision_inference)
+        self.allow_unvalidated_reduced_precision_inference = (allow_unvalidated_reduced_precision_inference)
         self.use_ema = use_ema
         self.ema_decay = ema_decay
         self.ema_update_after_step = ema_update_after_step
@@ -165,11 +158,8 @@ class F5TTSForTextToSpeech(PreTrainedTTSModel):
             self.config.torch_dtype,
             self.device,
         )
-        if (
-                not self._loading_for_training
-                and dtype != torch.float32
-                and not self.config.allow_unvalidated_reduced_precision_inference
-        ):
+        if (not self._loading_for_training and dtype != torch.float32 and
+                not self.config.allow_unvalidated_reduced_precision_inference):
             raise RuntimeError(
                 "F5-TTS reduced-precision inference is disabled by default "
                 f"for {str(dtype).removeprefix('torch.')}. Use "

--- a/voicehub/models/vad_webrtc/modeling_vad_webrtc.py
+++ b/voicehub/models/vad_webrtc/modeling_vad_webrtc.py
@@ -28,13 +28,7 @@ def _pcm16_samples(waveform: Any) -> list[int]:
         posinf=0.0,
         neginf=0.0,
     )
-    return (
-        values.clamp(-1.0, 1.0)
-        .mul(32767.0)
-        .round()
-        .to(torch.int32)
-        .tolist()
-    )
+    return (values.clamp(-1.0, 1.0).mul(32767.0).round().to(torch.int32).tolist())
 
 
 class WebRTCVADForVoiceActivityDetection(PreTrainedVADModel):

--- a/voicehub/models/vui/model.py
+++ b/voicehub/models/vui/model.py
@@ -411,10 +411,10 @@ class Vui(nn.Module):
         """Expose only quality-safe Vui compile boundaries.
 
         Real-checkpoint tests changed autoregressive generation for both
-        compiler-default and explicit dynamic inference policies. Inference
-        therefore exposes no compile target. Training retains its full-
-        sequence decoder boundary, which does not use mutable generation
-        caches or waveform reconstruction.
+        compiler-default and explicit dynamic inference policies.
+        Inference therefore exposes no compile target. Training retains
+        its full- sequence decoder boundary, which does not use mutable
+        generation caches or waveform reconstruction.
         """
         if mode == "training":
             return (OptimizationCompileTarget(
@@ -463,10 +463,7 @@ class Vui(nn.Module):
             is_native_checkpoint = (
                 direct_checkpoint.is_file() and direct_checkpoint.suffix.lower() == ".safetensors")
             if is_native_directory or is_native_checkpoint:
-                from voicehub.models.vui.checkpoint import (
-                    load_vui_safetensors,
-                    resolve_native_vui_artifact,
-                )
+                from voicehub.models.vui.checkpoint import load_vui_safetensors, resolve_native_vui_artifact
 
                 native_artifact = resolve_native_vui_artifact(direct_checkpoint, )
                 if (is_native_checkpoint and direct_checkpoint.resolve() != native_artifact.model_checkpoint):
@@ -511,11 +508,7 @@ class Vui(nn.Module):
             raise TypeError("Pass either `codec` or `codec_path`, not both.")
         if codec is None:
             if codec_path is None:
-                from voicehub.models.vui.artifacts import (
-                    VUI_CODEC_FILENAME,
-                    VUI_REPO_ID,
-                    VUI_REVISION,
-                )
+                from voicehub.models.vui.artifacts import VUI_CODEC_FILENAME, VUI_REPO_ID, VUI_REVISION
 
                 codec = Fluac.from_pretrained(
                     VUI_CODEC_FILENAME,

--- a/voicehub/optimization/torch_compile.py
+++ b/voicehub/optimization/torch_compile.py
@@ -20,11 +20,7 @@ from threading import RLock
 from types import MappingProxyType
 from typing import Any
 
-from voicehub.optimization.capabilities import (
-    OptimizationCapabilities,
-    OptimizationContext,
-    OptimizationMode,
-)
+from voicehub.optimization.capabilities import OptimizationCapabilities, OptimizationContext, OptimizationMode
 from voicehub.optimization.passes import (
     OptimizationCompatibilityError,
     OptimizationPass,
@@ -212,8 +208,7 @@ def torch_compile_architecture_incompatibility(
         f"Architecture {architecture_id!r} rejects torch.compile during "
         "inference because real-checkpoint validation changed generated "
         "tokens or audio under tested compiler policies. Training "
-        "compilation remains available."
-    )
+        "compilation remains available.")
 
 
 def _available_backends(torch: Any) -> tuple[str, ...]:
@@ -729,8 +724,7 @@ class TorchCompilePass(OptimizationPass):
     def validate(self, model: Any, context: OptimizationContext) -> None:
         super().validate(model, context)
         architecture_issue = self._architecture_incompatibility(context)
-        if (architecture_issue is not None and
-                self.config.requirement is TorchCompileRequirement.REQUIRED):
+        if (architecture_issue is not None and self.config.requirement is TorchCompileRequirement.REQUIRED):
             raise OptimizationCompatibilityError(architecture_issue)
         targets = self._execution_targets(model, context)
         report = inspect_torch_compile(self.config.backend)


### PR DESCRIPTION
Summary:
- add an evidence-first VoiceHub 0.3 release goal, loop, roadmap, and RC report
- verify version alignment, layered provider evidence, package provenance, license data, and exact publication artifacts
- add a protected Trusted Publishing workflow gated by tagged cross-platform tests
- normalize the existing repository formatting baseline

Local verification:
- full pytest on Python 3.10, 3.11, and 3.12
- pre-commit run --all-files
- mkdocs build --strict --clean
- python scripts/check_distribution.py
- python scripts/check_release.py --pypi-policy candidate

Publication is not requested by this PR. The protected pypi environment, tag, and final publish require separate maintainer approval.