### PR TITLE
docs: use English for agent responses

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -29,9 +29,9 @@ Complete one highest-impact bounded gap per iteration. Define observable
 completion evidence before editing, and do not create cosmetic work merely to
 keep a loop active.
 
-Write user-facing explanations in Turkish. Keep source code, identifiers,
-comments, docstrings, configuration, commit messages, pull request content, and
-repository documentation in English.
+Write all user-facing explanations and final reports in English. Keep source
+code, identifiers, comments, docstrings, configuration, commit messages, pull
+request content, and repository documentation in English.
 
 Preserve every existing user change. Never modify, stage, delete, regenerate,
 or overwrite the untracked `uv.lock` file.


### PR DESCRIPTION
## Summary
- make English the required language for all user-facing agent explanations and final reports
- keep the canonical instruction in `.ai/AGENTS.md`; root `AGENTS.md` and `CLAUDE.md` inherit it through their existing symlinks
- preserve all unrelated local documentation changes and `uv.lock`

## Verification
- `python3 -m unittest tests.test_ai_guidance` — 4 passed
- `uvx --from pre-commit pre-commit run --files .ai/AGENTS.md AGENTS.md CLAUDE.md` — all applicable hooks passed
- `git diff --check -- .ai/AGENTS.md` — passed
