### PR TITLE
docs: align the documentation shell with Transformers

### DIFF
--- a/docs/index.ar.md
+++ b/docs/index.ar.md
@@ -1,14 +1,11 @@
 ---
-hide:
-  - navigation
-  - toc
 description: وثائق VoiceHub للاستدلال الموحّد لأنظمة TTS، وإعداد البيانات، والضبط الدقيق المراعي للبنية المعمارية.
 ---
 
 <div class="vh-doc-home" markdown>
 
 <p class="vh-doc-logo">
-  <img src="assets/voicehub-mark.svg" alt="">
+  <img src="../assets/voicehub-mark.svg" alt="">
 </p>
 
 # VoiceHub: الاستدلال والتدريب لتحويل النص إلى كلام
@@ -25,7 +22,7 @@ description: وثائق VoiceHub للاستدلال الموحّد لأنظمة 
   </div>
   <span class="vh-doc-teaser__arrow" aria-hidden="true">→</span>
   <div class="vh-doc-teaser__model">
-    <img src="assets/voicehub-mark.svg" alt="">
+    <img src="../assets/voicehub-mark.svg" alt="">
     <strong>VoiceHub</strong>
     <span>مهايئ النموذج</span>
   </div>

--- a/docs/index.de.md
+++ b/docs/index.de.md
@@ -1,14 +1,11 @@
 ---
-hide:
-  - navigation
-  - toc
 description: VoiceHub-Dokumentation für einheitliche TTS-Inferenz, Datenaufbereitung und architekturspezifisches Fine-Tuning.
 ---
 
 <div class="vh-doc-home" markdown>
 
 <p class="vh-doc-logo">
-  <img src="assets/voicehub-mark.svg" alt="">
+  <img src="../assets/voicehub-mark.svg" alt="">
 </p>
 
 # VoiceHub: Text-zu-Sprache-Inferenz und Training
@@ -25,7 +22,7 @@ description: VoiceHub-Dokumentation für einheitliche TTS-Inferenz, Datenaufbere
   </div>
   <span class="vh-doc-teaser__arrow" aria-hidden="true">→</span>
   <div class="vh-doc-teaser__model">
-    <img src="assets/voicehub-mark.svg" alt="">
+    <img src="../assets/voicehub-mark.svg" alt="">
     <strong>VoiceHub</strong>
     <span>MODELLADAPTER</span>
   </div>

--- a/docs/index.es.md
+++ b/docs/index.es.md
@@ -1,14 +1,11 @@
 ---
-hide:
-  - navigation
-  - toc
 description: Documentación de VoiceHub para inferencia TTS unificada, preparación de datos y ajuste fino adaptado a cada arquitectura.
 ---
 
 <div class="vh-doc-home" markdown>
 
 <p class="vh-doc-logo">
-  <img src="assets/voicehub-mark.svg" alt="">
+  <img src="../assets/voicehub-mark.svg" alt="">
 </p>
 
 # VoiceHub: inferencia y entrenamiento de texto a voz
@@ -25,7 +22,7 @@ description: Documentación de VoiceHub para inferencia TTS unificada, preparaci
   </div>
   <span class="vh-doc-teaser__arrow" aria-hidden="true">→</span>
   <div class="vh-doc-teaser__model">
-    <img src="assets/voicehub-mark.svg" alt="">
+    <img src="../assets/voicehub-mark.svg" alt="">
     <strong>VoiceHub</strong>
     <span>ADAPTADOR DE MODELO</span>
   </div>

--- a/docs/index.fr.md
+++ b/docs/index.fr.md
@@ -1,14 +1,11 @@
 ---
-hide:
-  - navigation
-  - toc
 description: Documentation de VoiceHub pour l'inférence TTS unifiée, la préparation des données et l'ajustement adapté à chaque architecture.
 ---
 
 <div class="vh-doc-home" markdown>
 
 <p class="vh-doc-logo">
-  <img src="assets/voicehub-mark.svg" alt="">
+  <img src="../assets/voicehub-mark.svg" alt="">
 </p>
 
 # VoiceHub : inférence et entraînement de synthèse vocale
@@ -25,7 +22,7 @@ description: Documentation de VoiceHub pour l'inférence TTS unifiée, la prépa
   </div>
   <span class="vh-doc-teaser__arrow" aria-hidden="true">→</span>
   <div class="vh-doc-teaser__model">
-    <img src="assets/voicehub-mark.svg" alt="">
+    <img src="../assets/voicehub-mark.svg" alt="">
     <strong>VoiceHub</strong>
     <span>ADAPTATEUR DE MODÈLE</span>
   </div>

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -1,14 +1,11 @@
 ---
-hide:
-  - navigation
-  - toc
 description: 統一された TTS 推論、データ準備、アーキテクチャを考慮したファインチューニングのための VoiceHub ドキュメント。
 ---
 
 <div class="vh-doc-home" markdown>
 
 <p class="vh-doc-logo">
-  <img src="assets/voicehub-mark.svg" alt="">
+  <img src="../assets/voicehub-mark.svg" alt="">
 </p>
 
 # VoiceHub：音声合成の推論と学習
@@ -25,7 +22,7 @@ description: 統一された TTS 推論、データ準備、アーキテクチ�
   </div>
   <span class="vh-doc-teaser__arrow" aria-hidden="true">→</span>
   <div class="vh-doc-teaser__model">
-    <img src="assets/voicehub-mark.svg" alt="">
+    <img src="../assets/voicehub-mark.svg" alt="">
     <strong>VoiceHub</strong>
     <span>モデルアダプター</span>
   </div>

--- a/docs/index.ko.md
+++ b/docs/index.ko.md
@@ -1,14 +1,11 @@
 ---
-hide:
-  - navigation
-  - toc
 description: 통합 TTS 추론, 데이터 준비, 아키텍처 인식 미세 조정을 위한 VoiceHub 문서입니다.
 ---
 
 <div class="vh-doc-home" markdown>
 
 <p class="vh-doc-logo">
-  <img src="assets/voicehub-mark.svg" alt="">
+  <img src="../assets/voicehub-mark.svg" alt="">
 </p>
 
 # VoiceHub: 텍스트 음성 변환 추론 및 학습
@@ -25,7 +22,7 @@ description: 통합 TTS 추론, 데이터 준비, 아키텍처 인식 미세 조
   </div>
   <span class="vh-doc-teaser__arrow" aria-hidden="true">→</span>
   <div class="vh-doc-teaser__model">
-    <img src="assets/voicehub-mark.svg" alt="">
+    <img src="../assets/voicehub-mark.svg" alt="">
     <strong>VoiceHub</strong>
     <span>모델 어댑터</span>
   </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,4 @@
 ---
-hide:
-  - navigation
-  - toc
 description: VoiceHub documentation for unified TTS, ASR, and VAD inference, data preparation, and architecture-aware fine-tuning.
 ---
 

--- a/docs/index.pt.md
+++ b/docs/index.pt.md
@@ -1,14 +1,11 @@
 ---
-hide:
-  - navigation
-  - toc
 description: Documentação do VoiceHub para inferência TTS unificada, preparação de dados e ajuste fino orientado à arquitetura.
 ---
 
 <div class="vh-doc-home" markdown>
 
 <p class="vh-doc-logo">
-  <img src="assets/voicehub-mark.svg" alt="">
+  <img src="../assets/voicehub-mark.svg" alt="">
 </p>
 
 # VoiceHub: inferência e treinamento de síntese de voz
@@ -25,7 +22,7 @@ description: Documentação do VoiceHub para inferência TTS unificada, prepara�
   </div>
   <span class="vh-doc-teaser__arrow" aria-hidden="true">→</span>
   <div class="vh-doc-teaser__model">
-    <img src="assets/voicehub-mark.svg" alt="">
+    <img src="../assets/voicehub-mark.svg" alt="">
     <strong>VoiceHub</strong>
     <span>ADAPTADOR DE MODELO</span>
   </div>

--- a/docs/index.ru.md
+++ b/docs/index.ru.md
@@ -1,14 +1,11 @@
 ---
-hide:
-  - navigation
-  - toc
 description: Документация VoiceHub по унифицированному TTS-инференсу, подготовке данных и дообучению с учетом архитектуры модели.
 ---
 
 <div class="vh-doc-home" markdown>
 
 <p class="vh-doc-logo">
-  <img src="assets/voicehub-mark.svg" alt="">
+  <img src="../assets/voicehub-mark.svg" alt="">
 </p>
 
 # VoiceHub: инференс и обучение моделей синтеза речи
@@ -25,7 +22,7 @@ description: Документация VoiceHub по унифицированно
   </div>
   <span class="vh-doc-teaser__arrow" aria-hidden="true">→</span>
   <div class="vh-doc-teaser__model">
-    <img src="assets/voicehub-mark.svg" alt="">
+    <img src="../assets/voicehub-mark.svg" alt="">
     <strong>VoiceHub</strong>
     <span>АДАПТЕР МОДЕЛИ</span>
   </div>

--- a/docs/index.tr.md
+++ b/docs/index.tr.md
@@ -1,14 +1,11 @@
 ---
-hide:
-  - navigation
-  - toc
 description: Birleşik TTS çıkarımı, veri hazırlama ve mimariye duyarlı ince ayar için VoiceHub belgeleri.
 ---
 
 <div class="vh-doc-home" markdown>
 
 <p class="vh-doc-logo">
-  <img src="assets/voicehub-mark.svg" alt="">
+  <img src="../assets/voicehub-mark.svg" alt="">
 </p>
 
 # VoiceHub: Metinden Sese Çıkarım ve Eğitim
@@ -25,7 +22,7 @@ description: Birleşik TTS çıkarımı, veri hazırlama ve mimariye duyarlı in
   </div>
   <span class="vh-doc-teaser__arrow" aria-hidden="true">→</span>
   <div class="vh-doc-teaser__model">
-    <img src="assets/voicehub-mark.svg" alt="">
+    <img src="../assets/voicehub-mark.svg" alt="">
     <strong>VoiceHub</strong>
     <span>MODEL ADAPTÖRÜ</span>
   </div>

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -1,14 +1,11 @@
 ---
-hide:
-  - navigation
-  - toc
 description: VoiceHub 文档：统一的 TTS 推理、数据准备和架构感知微调。
 ---
 
 <div class="vh-doc-home" markdown>
 
 <p class="vh-doc-logo">
-  <img src="assets/voicehub-mark.svg" alt="">
+  <img src="../assets/voicehub-mark.svg" alt="">
 </p>
 
 # VoiceHub：文本转语音推理与训练
@@ -25,7 +22,7 @@ description: VoiceHub 文档：统一的 TTS 推理、数据准备和架构感�
   </div>
   <span class="vh-doc-teaser__arrow" aria-hidden="true">→</span>
   <div class="vh-doc-teaser__model">
-    <img src="assets/voicehub-mark.svg" alt="">
+    <img src="../assets/voicehub-mark.svg" alt="">
     <strong>VoiceHub</strong>
     <span>模型适配器</span>
   </div>

--- a/docs/javascripts/mobile-drawer.js
+++ b/docs/javascripts/mobile-drawer.js
@@ -1,0 +1,14 @@
+document.addEventListener("keydown", (event) => {
+  if (event.key !== "Escape") {
+    return;
+  }
+
+  const drawer = document.getElementById("__drawer");
+  if (!(drawer instanceof HTMLInputElement) || !drawer.checked) {
+    return;
+  }
+
+  event.preventDefault();
+  drawer.checked = false;
+  drawer.dispatchEvent(new Event("change", { bubbles: true }));
+});

--- a/docs/project/release-readiness.md
+++ b/docs/project/release-readiness.md
@@ -19,12 +19,12 @@ contract.
 | Gate | Current evidence | Status |
 | --- | --- | --- |
 | Source, docs, benchmark, and PyPI candidate alignment | Local check identified 0.3.0 as a new candidate over PyPI 0.1.6 | Passed |
-| Full CPU-safe suite | PR 69 exact head `3a3e224` passed the supported Linux, macOS, and Windows test matrix in [CI run 30742766090](https://github.com/kadirnar/voicehub/actions/runs/30742766090). The current uncommitted Python 3.12.12 tree reported 2,444 passed, 15 skipped, 3,406 subtests, and 35 warnings in 116.03 seconds | Passed remotely on Python 3.10-3.12 for `3a3e224` and locally on Python 3.12 for the uncommitted tree; five CUDA/Triton plus two inaccessible WeNet paths remain explicitly unverified |
-| Formatting and lint | PR 70 exact head `9bae722` passed `pre-commit.ci`; the current selected hook run first let YAPF format the new regression and exited nonzero, then passed every hook on the formatted files | Passed remotely for the merged source and locally on the current changed files; the failed formatter run is excluded |
-| Documentation | [Main Docs run 30745818292](https://github.com/kadirnar/voicehub/actions/runs/30745818292) passed for exact head `6a75eda`; the current uncommitted slice passed 30 documentation contracts with 1,132 subtests, 43 combined documentation/release/guidance tests with 1,143 subtests, and a strict eleven-language build | Passed remotely for the merged source and locally for the uncommitted slice; the reference mobile light render and remaining representative page matrix remain pending |
-| Wheel, sdist, and editable installs | [Main Package CI run 30745818302](https://github.com/kadirnar/voicehub/actions/runs/30745818302) passed for exact head `6a75eda`; the current local probe reported 68 models, 81 provenance manifests, 193 compliance files, required package data, zero dependency violations, and no eager PyTorch import from wheel, sdist, and editable installs | Passed remotely for the merged source and locally for the uncommitted slice; local wheel was 57,186,791 bytes and sdist was 55,427,312 bytes |
-| Python 3.10–3.12 on Linux, macOS, and Windows | PR 69 exact head `3a3e224` passed all nine version/platform jobs, both runtime smokes, default runtime, training, and lint in [CI run 30742766090](https://github.com/kadirnar/voicehub/actions/runs/30742766090) | Passed for exact head `3a3e224`; later uncommitted documentation changes are not covered by this remote run |
-| Canonical AI guidance | PR 69 exact head `3a3e224` passed the canonical guidance contract in every supported platform matrix job; the current tree's merged guidance change passed 13 local tests and 11 subtests | Passed cross-platform for `3a3e224` and locally for the current tree; the later guidance change has no exact-head platform matrix |
+| Full CPU-safe suite | PR 71 exact head `afd1d29` passed the supported Linux, macOS, and Windows test matrix in [CI run 30747565870](https://github.com/kadirnar/voicehub/actions/runs/30747565870). The latest recorded local Python 3.12.12 candidate reported 2,444 passed, 15 skipped, 3,406 subtests, and 35 warnings in 116.03 seconds | Passed remotely on Python 3.10-3.12 for `afd1d29` and locally on Python 3.12 for the recorded candidate; five CUDA/Triton plus two inaccessible WeNet paths remain explicitly unverified |
+| Formatting and lint | PR 71 exact head `afd1d29` passed CI lint and `pre-commit.ci`; the documentation-slice hook run first let YAPF format the new regression and exited nonzero, then passed every hook on the formatted files | Passed remotely for the exact candidate and locally on the documentation slice; the failed formatter run is excluded |
+| Documentation | PR 71 exact head `afd1d29` passed [Docs run 30747565866](https://github.com/kadirnar/voicehub/actions/runs/30747565866); the documentation-parity slice passed 30 documentation contracts with 1,132 subtests, 43 combined documentation/release/guidance tests with 1,143 subtests, and a strict eleven-language build | Passed remotely for the exact candidate and locally for the documentation-parity slice; the reference mobile light render and remaining representative page matrix remain pending |
+| Wheel, sdist, and editable installs | PR 71 exact head `afd1d29` passed [Package CI run 30747565842](https://github.com/kadirnar/voicehub/actions/runs/30747565842); the latest local probe reported 68 models, 81 provenance manifests, 193 compliance files, required package data, zero dependency violations, and no eager PyTorch import from wheel, sdist, and editable installs | Passed remotely for the exact candidate and locally for the recorded candidate; local wheel was 57,186,791 bytes and sdist was 55,427,312 bytes |
+| Python 3.10–3.12 on Linux, macOS, and Windows | PR 71 exact head `afd1d29` passed all nine version/platform jobs, both runtime smokes, default runtime, training, and lint in [CI run 30747565870](https://github.com/kadirnar/voicehub/actions/runs/30747565870) | Passed for exact head `afd1d29` |
+| Canonical AI guidance | PR 71 exact head `afd1d29` passed the canonical guidance contract in every supported platform matrix job; the current tree's merged guidance change passed 13 local tests and 11 subtests | Passed cross-platform for the exact candidate and locally for the current tree |
 | Released-checkpoint TTS, ASR, and VAD evidence | Dated RTX 4090 JSON and guide; see matrix below | Passed for the listed representatives |
 | Pinned small release assets | The official ESPNet configuration plus SenseVoice and SpeechBrain tokenizers at immutable revisions matched declared sizes, file fingerprints, extracted tokens, and published encoding vectors | Passed locally; Package CI and the tagged release build now repeat all three opt-in online gates |
 | TEN-VAD checkpoint oracle | The official 315,449-byte ONNX graph at immutable revision `22a3bcd4509d0faaa8eef4881e8af5f39c178950` converted to native Safetensors and matched ONNX Runtime across 25 recurrent steps | Passed locally with pinned ONNX Runtime 1.22.1; Package CI and the tagged build now repeat the isolated development oracle |
@@ -546,21 +546,30 @@ PR 69 exact head `3a3e224` passed every required job in CI run 30742766090.
 Current main head `6a75eda` subsequently passed Package CI and the strict
 documentation build in [runs 30745818302](https://github.com/kadirnar/voicehub/actions/runs/30745818302)
 and [30745818292](https://github.com/kadirnar/voicehub/actions/runs/30745818292).
-The local checkout is at `6a75eda` with a later uncommitted
-documentation-parity slice and this evidence update, so those remote results
-are not attributed to the uncommitted changes.
+The documentation-parity branch derives from `6a75eda`. PR 71 exact head
+`afd1d29` passed all nine platform/version jobs, both runtime smokes, default
+runtime, training, lint, strict documentation, package build, and
+`pre-commit.ci`. The documentation deployment job was skipped for the pull
+request and is not counted as a pass. This later evidence-only update does not
+alter the documentation-shell implementation; the pull request remains the
+authoritative source for its current exact-head status.
 
 The next left-navigation state slice maps the Transformers and VoiceHub
-Installation routes. At the available 1280 x 720 viewport, the reference
-current item rendered as a filled rounded control while VoiceHub's baseline
-was transparent text. VoiceHub now renders a 219 x 34-pixel filled and bordered
-active item in both light and dark themes, keeps the current `Get started`
-branch checked, exposes a two-pixel keyboard focus outline with a two-pixel
-offset, and has no horizontal overflow. The focused source regression first
-failed before the state styles existed. A rendered keyboard probe then exposed
-Material's `focus-visible` compatibility class; the first selector did not
-draw an outline, and that failed probe is not counted. The compatibility
-selector and focused regression now pass. The documentation file reported 30
+Installation routes. Exact rendered checks at 1440 x 900, 1024 x 768, and
+390 x 844 now cover one visible active item, the expanded current branch,
+visible keyboard focus, and zero horizontal overflow. VoiceHub rendered its
+219 x 34-pixel desktop item and 212 x 34-pixel tablet item in both light and
+dark themes. Its opened mobile drawer measured 242 pixels with a 133-pixel
+backdrop and exposed one 251 x 48-pixel active row in both themes. The mapped
+Transformers active item measured about 218 x 31 pixels at desktop and tablet
+widths and 323 x 31 pixels in its opened mobile navigation; all three reference
+states exposed visible keyboard focus without horizontal overflow. The focused
+source regression first failed before the state styles existed. A rendered
+keyboard probe then exposed Material's `focus-visible` compatibility class;
+the first selector did not draw an outline, and that failed probe is not
+counted. The compatibility selector and focused regression now pass; the exact
+viewport rerun's three focused navigation and drawer tests also pass. The
+documentation file reported 30
 passes and 1,132 subtests, the related registry and universal-optimization
 files reported 46 passes and 236 subtests, all 68 model pages and 59 model
 notebooks were current, release alignment found all five benchmark files, the
@@ -569,10 +578,8 @@ editable probes passed. The complete Python 3.12.12
 suite reported 2,444 passes, 15 explicit skips, 3,406 subtests, and 35 warnings
 in 116.03 seconds. The first selected hook run let YAPF format the new
 regression and exited nonzero; the formatted second run passed, so the first is
-not counted. The requested 1440 x 900, 1024 x 768, and 390 x 844 reruns remain
-pending: the responsive viewport override continued to expose 1280 x 720 and
-the Chrome fallback did not become controllable. Those inaccessible checks are
-not reported as passed.
+not counted. The reference mobile light state and the remaining representative
+page matrix remain pending and are not reported as passed.
 
 ## One-time publisher configuration
 

--- a/docs/project/release-readiness.md
+++ b/docs/project/release-readiness.md
@@ -19,11 +19,12 @@ contract.
 | Gate | Current evidence | Status |
 | --- | --- | --- |
 | Source, docs, benchmark, and PyPI candidate alignment | Local check identified 0.3.0 as a new candidate over PyPI 0.1.6 | Passed |
-| Full CPU-safe suite | Fresh default-offline Python 3.10.19 and 3.11.15 macOS environments each reported 2,434 passed, 15 skipped, 3,383 subtests, and 35 warnings; the fullest locally available Python 3.12.12 opt-in run reported 2,442 passed, 7 skipped, 3,521 subtests, and 35 warnings | Passed locally with full current-tree coverage on every supported interpreter; the ESPNet, SenseVoice, and SpeechBrain release assets, TEN-VAD and QuartzNet checkpoint oracles, and three default-runtime paths passed their explicit gates, while five CUDA/Triton and two inaccessible WeNet paths remain unverified |
-| Formatting and lint | A fresh repository-wide `pre-commit run --all-files` after the checkpoint-documentation, SpeechBrain release-asset, and supported-version slices passed every hook without a rewrite | Passed on the current working tree |
-| Documentation | Strict multilingual build completed locally and in [main Docs run 30710518245](https://github.com/kadirnar/voicehub/actions/runs/30710518245) | Passed |
-| Wheel, sdist, and editable installs | Current clean probes reported 68 models, 81 pinned/license-bearing source manifests, 193 installed provenance/legal files, required data present, zero dependency violations, and no eager PyTorch import; [main Package CI run 30710518275](https://github.com/kadirnar/voicehub/actions/runs/30710518275) passed independently | Passed |
-| Python 3.10–3.12 on Linux, macOS, and Windows | The current tree passed complete suites on Python 3.10.19, 3.11.15, and 3.12.12 on macOS; commit `f2d6332` passed all nine platform/version matrix jobs in [CI run 30710518249](https://github.com/kadirnar/voicehub/actions/runs/30710518249), plus runtime smokes, default-runtime, training, and lint jobs | Passed locally on every supported interpreter; the tagged nine-job matrix now enables the complete default-runtime gate, but Linux and Windows execution of the current uncommitted tree remains pending |
+| Full CPU-safe suite | PR 69 exact head `3a3e224` passed the supported Linux, macOS, and Windows test matrix in [CI run 30742766090](https://github.com/kadirnar/voicehub/actions/runs/30742766090). The current uncommitted Python 3.12.12 tree reported 2,444 passed, 15 skipped, 3,406 subtests, and 35 warnings in 116.03 seconds | Passed remotely on Python 3.10-3.12 for `3a3e224` and locally on Python 3.12 for the uncommitted tree; five CUDA/Triton plus two inaccessible WeNet paths remain explicitly unverified |
+| Formatting and lint | PR 70 exact head `9bae722` passed `pre-commit.ci`; the current selected hook run first let YAPF format the new regression and exited nonzero, then passed every hook on the formatted files | Passed remotely for the merged source and locally on the current changed files; the failed formatter run is excluded |
+| Documentation | [Main Docs run 30745818292](https://github.com/kadirnar/voicehub/actions/runs/30745818292) passed for exact head `6a75eda`; the current uncommitted slice passed 30 documentation contracts with 1,132 subtests, 43 combined documentation/release/guidance tests with 1,143 subtests, and a strict eleven-language build | Passed remotely for the merged source and locally for the uncommitted slice; the reference mobile light render and remaining representative page matrix remain pending |
+| Wheel, sdist, and editable installs | [Main Package CI run 30745818302](https://github.com/kadirnar/voicehub/actions/runs/30745818302) passed for exact head `6a75eda`; the current local probe reported 68 models, 81 provenance manifests, 193 compliance files, required package data, zero dependency violations, and no eager PyTorch import from wheel, sdist, and editable installs | Passed remotely for the merged source and locally for the uncommitted slice; local wheel was 57,186,791 bytes and sdist was 55,427,312 bytes |
+| Python 3.10–3.12 on Linux, macOS, and Windows | PR 69 exact head `3a3e224` passed all nine version/platform jobs, both runtime smokes, default runtime, training, and lint in [CI run 30742766090](https://github.com/kadirnar/voicehub/actions/runs/30742766090) | Passed for exact head `3a3e224`; later uncommitted documentation changes are not covered by this remote run |
+| Canonical AI guidance | PR 69 exact head `3a3e224` passed the canonical guidance contract in every supported platform matrix job; the current tree's merged guidance change passed 13 local tests and 11 subtests | Passed cross-platform for `3a3e224` and locally for the current tree; the later guidance change has no exact-head platform matrix |
 | Released-checkpoint TTS, ASR, and VAD evidence | Dated RTX 4090 JSON and guide; see matrix below | Passed for the listed representatives |
 | Pinned small release assets | The official ESPNet configuration plus SenseVoice and SpeechBrain tokenizers at immutable revisions matched declared sizes, file fingerprints, extracted tokens, and published encoding vectors | Passed locally; Package CI and the tagged release build now repeat all three opt-in online gates |
 | TEN-VAD checkpoint oracle | The official 315,449-byte ONNX graph at immutable revision `22a3bcd4509d0faaa8eef4881e8af5f39c178950` converted to native Safetensors and matched ONNX Runtime across 25 recurrent steps | Passed locally with pinned ONNX Runtime 1.22.1; Package CI and the tagged build now repeat the isolated development oracle |
@@ -433,7 +434,7 @@ metadata and size, and transfers those exact artifacts to a separate publish
 job.
 
 The latest clean-install build produced a 57,186,791-byte wheel and a
-55,426,668-byte source distribution. Fresh builds passed embedded name/version
+55,427,312-byte source distribution. Fresh builds passed embedded name/version
 checks; gzip timestamps can change archive bytes, so release hashes are recorded
 from the exact workflow artifacts rather than copied from a local build.
 
@@ -486,20 +487,92 @@ regression proves that the no-argument factory follows replaced registry
 metadata without changing `voicehub/auto.py`; missing and ambiguous defaults
 fail explicitly.
 
+PR 68 was merged as main commit `679d5bd` before its required matrix was green.
+PR 69 head `b6de7b5` subsequently repaired its canonical AI skill frontmatter
+and normalized materialized root-guidance pointers. CI run 30741892984 then
+passed every Linux and macOS Python job, both runtime smokes, default runtime,
+training, and lint. Windows 3.10, 3.11, and 3.12 each failed only the same two
+scaffold-checker assertions: actionable diagnostics rendered temporary
+repository-relative paths with native `\` separators while the public
+cross-platform contract expected stable `/` separators. Each Windows job
+otherwise reported 2,437 passes, 16 explicit skips, 3,392 subtests, and 35
+warnings.
+
+The bounded correction centralizes repository-relative display through
+`PurePath.as_posix()` and includes a dependency-free `PureWindowsPath`
+regression. The focused scaffold file reported 20 passes and 35 subtests; the
+related registry, model-page, optimization, release, and AI-guidance slice
+reported 113 passes and 1,849 subtests; selected pre-commit hooks, all 68
+generated model pages, all 59 notebooks, and release alignment also passed.
+The complete Python 3.12.12 suite reported 2,439 passes, 15 explicit skips,
+3,394 subtests, and 35 warnings in 115.67 seconds. That correction is now PR 69
+head `3a3e224`; [CI run 30742766090](https://github.com/kadirnar/voicehub/actions/runs/30742766090)
+passed every Linux, macOS, and Windows Python 3.10-3.12 job, both runtime
+smokes, default runtime, training, and lint.
+
+The following documentation-parity slices record the official Transformers
+`main` commit and toctree fingerprint, map representative routes, and restore
+the left navigation and right table of contents on all eleven localized home
+sources. Rendered checks at 1440 x 900, 1024 x 768, and 390 x 844 verified the
+desktop shell, mobile collapse, both VoiceHub palettes at all three viewports,
+and the absence of horizontal overflow. The tablet slice then matched the
+reference region behavior at 1024 x 768: a persistent 270-pixel left
+navigation, hidden right table of contents, 739-pixel content region inside the
+1,009-pixel main region, and no redundant drawer button. The mobile drawer and
+desktop three-column shell remained structurally unchanged. The drawer backdrop now excludes the
+242-pixel panel itself, leaving a 133 x 844 pointer target at 390 x 844. A real
+backdrop click in both LTR and RTL layouts and Escape in the LTR layout cleared
+the drawer checkbox and returned the panel off-canvas with no horizontal
+overflow. Initial probes against
+the full-width backdrop and the preexisting Escape behavior did not close the
+drawer; those failed checks are not counted. The final 30 documentation
+contracts reported 1,132 subtests, the related registry and optimization slice
+reported 70 passes and 310 subtests, all 68 generated model pages and 59
+notebooks were current, and the strict multilingual build completed. Release
+alignment, 13 AI-guidance and release-readiness tests with 11
+subtests, and selected hooks also passed. Fresh wheel, source-distribution, and
+editable probes passed with the inventory recorded above. The earlier shell
+slice's first selected hook run let YAPF format its regression and exited
+nonzero; the formatted regression and second hook run passed, so the failed run
+is not counted as passing evidence.
+
 The distribution gate inventories every `SOURCE.json`, license, licence,
 NOTICE, and COPYING file under the installed package. Each of the 81 source
 manifests must contain a pinned revision/release and explicit license metadata;
 all 193 compliance files plus the project-level Apache-2.0 license must survive
 both wheel and source-distribution builds.
 
-Remote main commit `f2d6332` passed Continuous Integration, Package CI, and the
-strict documentation build in
-[runs 30710518249](https://github.com/kadirnar/voicehub/actions/runs/30710518249),
-[30710518275](https://github.com/kadirnar/voicehub/actions/runs/30710518275), and
-[30710518245](https://github.com/kadirnar/voicehub/actions/runs/30710518245).
-The local branch is three commits behind that SHA and has later uncommitted
-changes, so those remote results are not attributed to the current working
-tree.
+PR 69 exact head `3a3e224` passed every required job in CI run 30742766090.
+Current main head `6a75eda` subsequently passed Package CI and the strict
+documentation build in [runs 30745818302](https://github.com/kadirnar/voicehub/actions/runs/30745818302)
+and [30745818292](https://github.com/kadirnar/voicehub/actions/runs/30745818292).
+The local checkout is at `6a75eda` with a later uncommitted
+documentation-parity slice and this evidence update, so those remote results
+are not attributed to the uncommitted changes.
+
+The next left-navigation state slice maps the Transformers and VoiceHub
+Installation routes. At the available 1280 x 720 viewport, the reference
+current item rendered as a filled rounded control while VoiceHub's baseline
+was transparent text. VoiceHub now renders a 219 x 34-pixel filled and bordered
+active item in both light and dark themes, keeps the current `Get started`
+branch checked, exposes a two-pixel keyboard focus outline with a two-pixel
+offset, and has no horizontal overflow. The focused source regression first
+failed before the state styles existed. A rendered keyboard probe then exposed
+Material's `focus-visible` compatibility class; the first selector did not
+draw an outline, and that failed probe is not counted. The compatibility
+selector and focused regression now pass. The documentation file reported 30
+passes and 1,132 subtests, the related registry and universal-optimization
+files reported 46 passes and 236 subtests, all 68 model pages and 59 model
+notebooks were current, release alignment found all five benchmark files, the
+strict multilingual documentation and fresh wheel, source-distribution, and
+editable probes passed. The complete Python 3.12.12
+suite reported 2,444 passes, 15 explicit skips, 3,406 subtests, and 35 warnings
+in 116.03 seconds. The first selected hook run let YAPF format the new
+regression and exited nonzero; the formatted second run passed, so the first is
+not counted. The requested 1440 x 900, 1024 x 768, and 390 x 844 reruns remain
+pending: the responsive viewport override continued to expose 1280 x 720 and
+the Chrome fallback did not become controllable. Those inaccessible checks are
+not reported as passed.
 
 ## One-time publisher configuration
 

--- a/docs/project/transformers-parity.md
+++ b/docs/project/transformers-parity.md
@@ -46,7 +46,7 @@ as top-level parity.
 | Page type | Transformers route | VoiceHub route | Structural shell | Responsive and visual status |
 | --- | --- | --- | --- | --- |
 | Home | `/docs/transformers/main/en/index` | `/voicehub/` | Left navigation and right table of contents are present at desktop width | Partial: desktop, tablet, and mobile shell behavior plus light/dark VoiceHub states, pointer dismissal, and Escape dismissal verified; the reference mobile light state and remaining interaction matrix remain gaps |
-| Installation | `/docs/transformers/main/en/installation` | `/voicehub/getting-started/installation/` | Partial: mapped active left-navigation item and expanded current section verified | Partial: light and dark active styling plus keyboard focus verified at the available 1280 x 720 viewport; exact desktop, tablet, and mobile reruns remain pending |
+| Installation | `/docs/transformers/main/en/installation` | `/voicehub/getting-started/installation/` | Mapped active left-navigation item and expanded current section verified | Partial: active styling, expanded state, keyboard focus, and overflow verified at 1440 x 900, 1024 x 768, and 390 x 844; remaining shell interactions are pending |
 | Quickstart | `/docs/transformers/main/en/quicktour` | `/voicehub/getting-started/quickstart/` | Pending | Pending |
 | Task guide | `/docs/transformers/main/en/pipeline_tutorial` | `/voicehub/guides/inference/` | Pending | Pending |
 | Model index | `/docs/transformers/main/en/model_doc/auto` | `/voicehub/models/providers/` | Pending | Pending |
@@ -61,7 +61,7 @@ as top-level parity.
 | Component or state | Current evidence | Remaining gate |
 | --- | --- | --- |
 | Global header | VoiceHub product, repository, search, theme, and language controls render | Ordering, geometry, focus, and expanded states |
-| Left navigation | Visible on desktop; persistent and 270 pixels wide at 1024 pixels; the home active item and keyboard focus render at 1440 x 900; the mobile drawer opens and closes by backdrop click or Escape in LTR and RTL layouts; the Installation route has a filled active item, expanded current section, and visible keyboard focus in light and dark themes at 1280 x 720 | Repeat Installation active, focus, and expanded-state evidence at the exact tablet and mobile viewports |
+| Left navigation | Visible on desktop; persistent and 270 pixels wide at 1024 pixels; the home active item and keyboard focus render at 1440 x 900; the mobile drawer opens and closes by backdrop click or Escape in LTR and RTL layouts; the Installation route has one visible filled active item, an expanded current section, and visible keyboard focus at 1440 x 900, 1024 x 768, and 390 x 844 in light and dark VoiceHub themes | Remaining representative routes, focus order, and sticky behavior |
 | Right table of contents | Visible on desktop; collapsed at tablet and mobile widths | Sticky and scroll-active states |
 | Main content | No horizontal overflow at the three checked viewports | Representative page typography, spacing, tables, callouts, tabs, and code actions |
 | Footer and page actions | Edit, previous/next, back-to-top, and footer regions render | Geometry, focus order, and all representative page pairs |
@@ -131,21 +131,22 @@ indigo outline with a two-pixel offset.
 ## Installation navigation-state evidence
 
 The mapped Transformers Installation page renders its current left-navigation
-item as a rounded filled control. At the available 1280 x 720 viewport, the
-reference active item measured about 218 x 31 pixels. VoiceHub's original
-active item was a transparent 210 x 22-pixel text link. The rebuilt VoiceHub
-item measures 219 x 34 pixels, uses the VoiceHub palette for its filled and
-bordered state, keeps the `Get started` branch checked, and has no horizontal
-overflow. The same active state rendered against the light and `slate` dark
-surfaces. Keyboard traversal applied Material's `focus-visible` class and the
-link rendered a two-pixel outline with a two-pixel offset.
+item as a rounded filled control. At 1440 x 900, the reference item measured
+about 218 x 31 pixels and VoiceHub measured 219 x 34 pixels. VoiceHub rendered
+one visible active item, kept the `Get started` branch checked, and had no
+horizontal overflow in its default light and `slate` dark themes. Keyboard
+traversal rendered a two-pixel theme-colored outline with a two-pixel offset.
 
-The responsive browser's requested 1440 x 900, 1024 x 768, and 390 x 844
-overrides all continued to report 1280 x 720, and the Chrome fallback did not
-become controllable. Those attempts are inaccessible checks, not passing
-evidence. This slice therefore leaves the exact three-viewport navigation-state
-matrix open even though the source regression, available desktop render, and
-strict documentation build pass.
+At 1024 x 768, the reference retained its 218 x 31-pixel active item. VoiceHub
+retained a persistent 270-pixel sidebar, rendered one 212 x 34-pixel active
+item in both themes, hid the mobile drawer button, kept `Get started` checked,
+and had no horizontal overflow. At 390 x 844, the VoiceHub drawer opened to
+242 pixels and its backdrop occupied the remaining 133 pixels. The current
+page became one visible 251 x 48-pixel active row, `Get started` remained
+checked, and a keyboard-focused drawer link rendered the same two-pixel focus
+treatment in both themes. The mapped Transformers drawer rendered one filled
+323 x 31-pixel Installation item with a visible keyboard focus outline. Both
+mobile pages had zero horizontal overflow.
 
 The following gaps remain explicit and are not passed by this slice:
 
@@ -153,8 +154,8 @@ The following gaps remain explicit and are not passed by this slice:
   Transformers-aligned navigation sections.
 - Header product, search, version, language, and source controls do not yet
   match the reference geometry or ordering.
-- Exact sticky behavior and the Installation focus and expanded-state matrix at
-  1440 x 900, 1024 x 768, and 390 x 844 are not yet verified.
+- Exact sticky behavior and the remaining representative-route focus and
+  expanded-state matrix are not yet verified.
 - The reference mobile light screenshot and remaining representative page-type
   matrix are pending. Home evidence covers both themes at all three VoiceHub
   viewports, both reference themes at desktop and tablet, and reference dark at

--- a/docs/project/transformers-parity.md
+++ b/docs/project/transformers-parity.md
@@ -1,0 +1,162 @@
+---
+description: Versioned route mappings and rendered evidence for VoiceHub documentation parity with Transformers.
+---
+
+# Transformers documentation parity
+
+This inventory records evidence instead of treating visual similarity as a
+claim. A mapped route is not complete until its structure, interactions,
+responsive states, accessibility, and screenshots have been checked.
+
+## Reference snapshot
+
+| Property | Value |
+| --- | --- |
+| Retrieved | 2026-08-02 |
+| Transformers branch | `main` |
+| Transformers commit | `b3a36037d3feb22e3f0174b3dd4248fcc0f0f722` |
+| `_toctree.yml` SHA-256 | `f7d0504e36cd7c312968b549af4fe02b6ee7b3c23d8023986e6a5824680c8f3a` |
+| Rendered reference | `https://huggingface.co/docs/transformers/main/en/index` |
+| VoiceHub route | `/voicehub/` |
+
+The modern VoiceHub color tokens and speech-specific content are intentional
+differences. Other shell, geometry, navigation, and interaction differences
+remain gaps until the table below records executed evidence.
+
+## Top-level navigation inventory
+
+| Transformers section | Current VoiceHub route | Current placement | Parity status |
+| --- | --- | --- | --- |
+| Get started | `/voicehub/` | Top level, first | Present |
+| Base classes | `/voicehub/reference/api/` | No dedicated top-level section | Gap |
+| Inference | `/voicehub/guides/inference/` | Nested under Guides | Gap |
+| Training | `/voicehub/guides/training/` | Nested under Guides | Gap |
+| Quantization and optimization | `/voicehub/guides/tts-optimization/` | Nested under Guides; no quantization landing page | Gap |
+| Ecosystem integrations | `/voicehub/guides/llm-serving/` | No dedicated top-level section | Gap |
+| Resources | `/voicehub/guides/notebook/` | No dedicated top-level section | Gap |
+| API | `/voicehub/reference/api/` | Top level, fourth | Present, wrong order |
+
+VoiceHub currently exposes five top-level sections: Get started, Models,
+Guides, API reference, and Project. The required eight-section hierarchy is a
+separate navigation slice; this iteration does not count nested destinations
+as top-level parity.
+
+## Representative page inventory
+
+| Page type | Transformers route | VoiceHub route | Structural shell | Responsive and visual status |
+| --- | --- | --- | --- | --- |
+| Home | `/docs/transformers/main/en/index` | `/voicehub/` | Left navigation and right table of contents are present at desktop width | Partial: desktop, tablet, and mobile shell behavior plus light/dark VoiceHub states, pointer dismissal, and Escape dismissal verified; the reference mobile light state and remaining interaction matrix remain gaps |
+| Installation | `/docs/transformers/main/en/installation` | `/voicehub/getting-started/installation/` | Partial: mapped active left-navigation item and expanded current section verified | Partial: light and dark active styling plus keyboard focus verified at the available 1280 x 720 viewport; exact desktop, tablet, and mobile reruns remain pending |
+| Quickstart | `/docs/transformers/main/en/quicktour` | `/voicehub/getting-started/quickstart/` | Pending | Pending |
+| Task guide | `/docs/transformers/main/en/pipeline_tutorial` | `/voicehub/guides/inference/` | Pending | Pending |
+| Model index | `/docs/transformers/main/en/model_doc/auto` | `/voicehub/models/providers/` | Pending | Pending |
+| Model detail | `/docs/transformers/main/en/model_doc/speecht5` | `/voicehub/models/providers/speecht5/` | Pending | Pending |
+| Training | `/docs/transformers/main/en/trainer` | `/voicehub/guides/training/` | Pending | Pending |
+| Optimization | `/docs/transformers/main/en/perf_infer_gpu_one` | `/voicehub/guides/tts-optimization/` | Pending | Pending |
+| Contribution | `/docs/transformers/main/en/add_new_model` | `/voicehub/project/adding-a-model/` | Pending | Pending |
+| API reference | `/docs/transformers/main/en/main_classes/model` | `/voicehub/reference/api/` | Pending | Pending |
+
+## Shared component and interaction inventory
+
+| Component or state | Current evidence | Remaining gate |
+| --- | --- | --- |
+| Global header | VoiceHub product, repository, search, theme, and language controls render | Ordering, geometry, focus, and expanded states |
+| Left navigation | Visible on desktop; persistent and 270 pixels wide at 1024 pixels; the home active item and keyboard focus render at 1440 x 900; the mobile drawer opens and closes by backdrop click or Escape in LTR and RTL layouts; the Installation route has a filled active item, expanded current section, and visible keyboard focus in light and dark themes at 1280 x 720 | Repeat Installation active, focus, and expanded-state evidence at the exact tablet and mobile viewports |
+| Right table of contents | Visible on desktop; collapsed at tablet and mobile widths | Sticky and scroll-active states |
+| Main content | No horizontal overflow at the three checked viewports | Representative page typography, spacing, tables, callouts, tabs, and code actions |
+| Footer and page actions | Edit, previous/next, back-to-top, and footer regions render | Geometry, focus order, and all representative page pairs |
+| Theme | VoiceHub light and dark renders completed at desktop, tablet, and mobile; reference light and dark renders completed at desktop and tablet, with dark completed at mobile | Reference mobile light render and remaining representative page types |
+
+## Registry, public-contract, and contribution inventory
+
+- The live registry contains 68 integrations: 34 TTS, 23 ASR, and 11 VAD.
+  All 68 generated model pages and navigation entries are current. None of the
+  68 generated provider-page titles currently has an uppercase-first display
+  name, so model display-name parity remains open.
+- The public optimization registry exposes `codec-kernels`, `compile`,
+  `custom-kernels`, `diffusion-cache`, `diffusion-sampling`, and
+  `flash-attention-4`. The registry inventory therefore contains 408
+  optimization/model pairs. The existing universal-contract slice passes, but
+  the Goal-level application, validation, restoration, reporting,
+  serialization, and semantic evidence audit for every pair remains open.
+- `AutoConfig`, task-specific auto models, `AutoProcessor`, pretrained model
+  bases, normalized typed outputs, `Trainer`, `TrainingArguments`, generation
+  and inference configurations, registry APIs, and save/load methods provide
+  the current Transformers-style mental-model surface. An object-by-object
+  parity audit remains open and this inventory does not treat naming alone as
+  behavioral parity.
+- The documented contribution path contains seven steps: audit, configure,
+  wrap, register, describe, test, and document. Its scaffold covers the model
+  package, configuration, runtime, registration, manifest, pinned source and
+  license, focused test, optional architecture package, and generated page.
+  Exact comparison with the current Modular Transformers contribution path
+  remains open.
+
+## Home shell baseline
+
+At a 1440 x 900 desktop viewport, the reference page rendered a persistent
+left documentation navigation and a right table of contents. VoiceHub
+previously set `hide: [navigation, toc]` on every localized home page,
+producing one wide content column. The home sources now retain both shell
+regions for all eleven built locales. Localized home hero images use
+parent-relative asset URLs so they resolve through the shared site asset
+directory instead of locale-local 404 routes. The rebuilt English home
+rendered a 242-pixel left navigation, 736-pixel content column, and 242-pixel
+right table of contents inside a 1,220-pixel main region with no horizontal
+overflow.
+
+The responsive comparison used the same rendered routes at 1024 x 768 and
+390 x 844. VoiceHub had no horizontal overflow at either size. At tablet
+width, both sites now retain a 270-pixel left navigation and remove the right
+table of contents; VoiceHub's 1,009-pixel main region leaves a 739-pixel content
+region beside the navigation after accounting for the viewport scrollbar.
+VoiceHub hides the redundant documentation-drawer button in this state. At
+mobile width, both sites collapse their documentation navigation and table of
+contents, and VoiceHub retains the working drawer button. VoiceHub rendered its
+default light palette and `slate` dark palette at all three viewports without
+horizontal overflow. The reference rendered in light and dark modes at desktop
+and tablet widths and in dark mode at mobile width; its mobile shell does not
+expose the theme selector, so the reference mobile light render remains
+pending. The VoiceHub drawer opened from its unique header control. Its LTR
+backdrop starts after the 242-pixel drawer and occupies the remaining 133 x 844
+rendered pixels. The Arabic RTL render mirrors those regions, placing the
+drawer at x = 133 and the backdrop at x = 0. Pointer dismissal closed both
+drawers. Escape also closed the English drawer through the loaded keyboard
+handler. The English paths returned the sidebar to x = -242 pixels and the RTL
+path returned it to x = 375 after the transition; horizontal overflow remained
+zero throughout. The desktop active link rendered with a highlighted
+background and 700 font weight, while keyboard focus rendered a two-pixel
+indigo outline with a two-pixel offset.
+
+## Installation navigation-state evidence
+
+The mapped Transformers Installation page renders its current left-navigation
+item as a rounded filled control. At the available 1280 x 720 viewport, the
+reference active item measured about 218 x 31 pixels. VoiceHub's original
+active item was a transparent 210 x 22-pixel text link. The rebuilt VoiceHub
+item measures 219 x 34 pixels, uses the VoiceHub palette for its filled and
+bordered state, keeps the `Get started` branch checked, and has no horizontal
+overflow. The same active state rendered against the light and `slate` dark
+surfaces. Keyboard traversal applied Material's `focus-visible` class and the
+link rendered a two-pixel outline with a two-pixel offset.
+
+The responsive browser's requested 1440 x 900, 1024 x 768, and 390 x 844
+overrides all continued to report 1280 x 720, and the Chrome fallback did not
+become controllable. Those attempts are inaccessible checks, not passing
+evidence. This slice therefore leaves the exact three-viewport navigation-state
+matrix open even though the source regression, available desktop render, and
+strict documentation build pass.
+
+The following gaps remain explicit and are not passed by this slice:
+
+- VoiceHub still has five top-level product tabs instead of the eight required
+  Transformers-aligned navigation sections.
+- Header product, search, version, language, and source controls do not yet
+  match the reference geometry or ordering.
+- Exact sticky behavior and the Installation focus and expanded-state matrix at
+  1440 x 900, 1024 x 768, and 390 x 844 are not yet verified.
+- The reference mobile light screenshot and remaining representative page-type
+  matrix are pending. Home evidence covers both themes at all three VoiceHub
+  viewports, both reference themes at desktop and tablet, and reference dark at
+  mobile.
+- The remaining representative page pairs have not been rendered or audited.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -339,8 +339,20 @@ body {
 }
 
 .md-nav__link--active {
+  margin-inline: -0.45rem 0;
+  padding: 0.3rem 0.45rem;
+  border-radius: 0.45rem;
+  background: color-mix(in srgb, var(--vh-indigo) 11%, var(--vh-surface));
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--vh-indigo) 22%, transparent);
   color: var(--vh-indigo);
-  font-weight: 650;
+  font-weight: 700;
+}
+
+.md-nav__link[href]:focus-visible,
+.md-nav__link[href].focus-visible {
+  outline: 2px solid var(--vh-indigo);
+  outline-offset: 2px;
 }
 
 .md-footer {
@@ -651,6 +663,121 @@ body {
   color: var(--vh-muted);
   font-size: 0.82rem;
   line-height: 1.5;
+}
+
+/* Keep the mobile backdrop's pointer target outside the open drawer. */
+
+@media screen and (max-width: 59.984375em) {
+  [dir="ltr"] [data-md-toggle="drawer"]:checked ~ .md-overlay {
+    right: 0;
+    left: 12.1rem;
+    width: calc(100% - 12.1rem);
+  }
+
+  [dir="rtl"] [data-md-toggle="drawer"]:checked ~ .md-overlay {
+    right: 12.1rem;
+    left: 0;
+    width: calc(100% - 12.1rem);
+  }
+}
+
+/* Keep the documentation navigation persistent at the reference tablet width. */
+
+@media screen and (min-width: 60em) and (max-width: 76.234375em) {
+  .md-header__button[for="__drawer"] {
+    display: none;
+  }
+
+  [dir="ltr"] .md-sidebar--primary,
+  [dir="rtl"] .md-sidebar--primary {
+    position: sticky;
+    top: 3.2rem;
+    right: auto;
+    left: auto;
+    width: 13.5rem;
+    height: 0;
+    background-color: transparent;
+    transform: none;
+    transition: none;
+    z-index: auto;
+  }
+
+  .md-sidebar--primary .md-sidebar__scrollwrap {
+    position: static;
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    height: calc(100vh - 7.1rem);
+    overflow-y: auto;
+    scroll-snap-type: y mandatory;
+    touch-action: pan-y;
+  }
+
+  .md-nav--primary,
+  .md-nav--primary .md-nav {
+    position: static;
+    height: auto;
+    background-color: transparent;
+  }
+
+  .md-nav--primary {
+    display: block;
+  }
+
+  .md-nav--primary > .md-nav__title {
+    display: none;
+  }
+
+  .md-nav--primary > .md-nav__list {
+    flex: none;
+    height: auto;
+    overflow: visible;
+    padding-inline: 0.6rem 0;
+  }
+
+  .md-nav--primary .md-nav__item {
+    border-top: 0;
+    font-size: 0.76rem;
+    line-height: 1.45;
+  }
+
+  .md-nav--primary .md-nav__link {
+    margin-top: 0.625em;
+    padding: 0;
+  }
+
+  .md-nav--primary .md-nav__link--active {
+    margin-inline: -0.45rem 0;
+    padding: 0.3rem 0.45rem;
+  }
+
+  .md-nav__toggle ~ .md-nav {
+    display: grid;
+    grid-template-rows: minmax(0.4rem, 0fr);
+    opacity: 0;
+    transform: none;
+    visibility: collapse;
+  }
+
+  .md-nav__toggle ~ .md-nav > .md-nav__list {
+    overflow: hidden;
+  }
+
+  .md-nav__toggle.md-toggle--indeterminate ~ .md-nav,
+  .md-nav__toggle:checked ~ .md-nav {
+    grid-template-rows: minmax(0.4rem, 1fr);
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .md-nav__item--nested > .md-nav > .md-nav__title {
+    display: none;
+  }
+
+  .md-sidebar--secondary:not([hidden]) {
+    display: none;
+  }
 }
 
 @media screen and (max-width: 44.984375em) {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,6 +158,7 @@ nav:
       - Trainer architecture: concepts/trainer.md
       - Roadmap: project/roadmap.md
       - Release readiness: project/release-readiness.md
+      - Transformers parity: project/transformers-parity.md
       - Add a TTS model: project/adding-a-model.md
       - Add an ASR or VAD provider: project/adding-speech-provider.md
       - Add an optimization: project/adding-an-optimization.md
@@ -482,6 +483,9 @@ markdown_extensions:
 
 extra_css:
   - stylesheets/extra.css
+
+extra_javascript:
+  - javascripts/mobile-drawer.js
 
 extra:
   social:

--- a/tests/test_documentation_site.py
+++ b/tests/test_documentation_site.py
@@ -38,6 +38,7 @@ README_PATH = REPOSITORY_ROOT / "README.md"
 PYPROJECT_PATH = REPOSITORY_ROOT / "pyproject.toml"
 THEME_OVERRIDE_PATH = REPOSITORY_ROOT / "overrides" / "main.html"
 STYLESHEET_PATH = DOCS_ROOT / "stylesheets" / "extra.css"
+MOBILE_DRAWER_SCRIPT_PATH = DOCS_ROOT / "javascripts" / "mobile-drawer.js"
 PUBLIC_SITE_URL = "https://kadirnar.github.io/voicehub/"
 LOCALIZED_HOME_LOCALES = ("ar", "de", "es", "fr", "ja", "ko", "pt", "ru", "tr", "zh")
 TOP_LEVEL_NAVIGATION = (
@@ -93,6 +94,7 @@ NAVIGATION_PATHS = (
     "project/adding-a-model.md",
     "project/adding-speech-provider.md",
     "project/adding-an-optimization.md",
+    "project/transformers-parity.md",
     "project/translations.md",
     "project/model-audit.md",
 )
@@ -692,6 +694,87 @@ print(json.dumps({name: name in sys.modules for name in blocked}))
                 localized_source = localized_home.read_text(encoding="utf-8")
                 self.assertIn('<div class="vh-doc-home" markdown>', localized_source)
                 self.assertIn('<div class="grid cards" markdown>', localized_source)
+
+    def test_homepages_keep_the_transformers_shell_visible(self):
+        parity_inventory = (DOCS_ROOT / "project" / "transformers-parity.md").read_text(encoding="utf-8")
+        self.assertIn("b3a36037d3feb22e3f0174b3dd4248fcc0f0f722", parity_inventory)
+        self.assertIn("/docs/transformers/main/en/index", parity_inventory)
+
+        homepages = (DOCS_ROOT / "index.md", ) + tuple(
+            DOCS_ROOT / f"index.{locale}.md" for locale in LOCALIZED_HOME_LOCALES)
+        for homepage in homepages:
+            with self.subTest(homepage=homepage):
+                source = homepage.read_text(encoding="utf-8")
+                frontmatter = source.split("---\n", 2)[1]
+                self.assertNotIn("hide:", frontmatter)
+                self.assertNotIn("navigation", frontmatter)
+                self.assertNotIn("toc", frontmatter)
+                expected_mark_path = (
+                    "assets/voicehub-mark.svg" if homepage == DOCS_ROOT /
+                    "index.md" else "../assets/voicehub-mark.svg")
+                self.assertEqual(source.count(f'src="{expected_mark_path}"'), 2)
+
+    def test_tablet_shell_keeps_primary_navigation_in_the_layout(self):
+        stylesheet = STYLESHEET_PATH.read_text(encoding="utf-8")
+        tablet_shell = stylesheet.split(
+            "@media screen and (min-width: 60em) and (max-width: 76.234375em)",
+            1,
+        )[1].split("@media screen and (max-width: 44.984375em)", 1)[0]
+
+        self.assertIn('.md-header__button[for="__drawer"]', tablet_shell)
+        self.assertIn('[dir="ltr"] .md-sidebar--primary', tablet_shell)
+        self.assertIn("position: sticky", tablet_shell)
+        self.assertIn("width: 13.5rem", tablet_shell)
+        self.assertIn(".md-sidebar--primary .md-sidebar__scrollwrap", tablet_shell)
+        self.assertIn("overflow-y: auto", tablet_shell)
+        self.assertIn(".md-nav--primary > .md-nav__title", tablet_shell)
+        self.assertIn(".md-nav__toggle:checked ~ .md-nav", tablet_shell)
+        self.assertIn("visibility: visible", tablet_shell)
+        self.assertIn(".md-sidebar--secondary:not([hidden])", tablet_shell)
+        self.assertIn("display: none", tablet_shell)
+
+    def test_left_navigation_marks_active_and_keyboard_focus_states(self):
+        stylesheet = STYLESHEET_PATH.read_text(encoding="utf-8")
+        active_state = stylesheet.split(".md-nav__link--active {", 1)[1].split("}", 1)[0]
+        focus_selector = (".md-nav__link[href]:focus-visible,\n"
+                          ".md-nav__link[href].focus-visible {")
+        focus_state = stylesheet.split(focus_selector, 1)[1].split("}", 1)[0]
+
+        self.assertIn("background:", active_state)
+        self.assertIn("box-shadow:", active_state)
+        self.assertIn("border-radius:", active_state)
+        self.assertIn(".md-nav__link[href].focus-visible", stylesheet)
+        self.assertIn("outline: 2px solid var(--vh-indigo)", focus_state)
+        self.assertIn("outline-offset: 2px", focus_state)
+
+    def test_mobile_drawer_overlay_click_target_stays_outside_the_panel(self):
+        stylesheet = STYLESHEET_PATH.read_text(encoding="utf-8")
+        mobile_overlay = stylesheet.split(
+            "@media screen and (max-width: 59.984375em)",
+            1,
+        )[1].split(
+            "@media screen and (min-width: 60em) and (max-width: 76.234375em)",
+            1,
+        )[0]
+
+        self.assertIn('[dir="ltr"] [data-md-toggle="drawer"]:checked ~ .md-overlay', mobile_overlay)
+        self.assertIn('[dir="rtl"] [data-md-toggle="drawer"]:checked ~ .md-overlay', mobile_overlay)
+        self.assertIn("left: 12.1rem", mobile_overlay)
+        self.assertIn("right: 12.1rem", mobile_overlay)
+        self.assertEqual(mobile_overlay.count("width: calc(100% - 12.1rem)"), 2)
+
+    def test_mobile_drawer_escape_dismissal_is_loaded(self):
+        site_config = SITE_CONFIG_PATH.read_text(encoding="utf-8")
+        script = MOBILE_DRAWER_SCRIPT_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("javascripts/mobile-drawer.js", site_config)
+        self.assertIn('document.addEventListener("keydown"', script)
+        self.assertIn('event.key !== "Escape"', script)
+        self.assertIn('document.getElementById("__drawer")', script)
+        self.assertIn("!drawer.checked", script)
+        self.assertIn("event.preventDefault()", script)
+        self.assertIn("drawer.checked = false", script)
+        self.assertIn('drawer.dispatchEvent(new Event("change", { bubbles: true }))', script)
 
     def test_process_overviews_are_readable_without_horizontal_scrolling(self):
         for page_path, expected_steps in PROCESS_PAGE_STEPS:


### PR DESCRIPTION
## Transformers reference

- Upstream: `huggingface/transformers` `main` at `b3a36037d3feb22e3f0174b3dd4248fcc0f0f722`, retrieved 2026-08-02.
- Navigation source: `docs/source/en/_toctree.yml`, SHA-256 `f7d0504e36cd7c312968b549af4fe02b6ee7b3c23d8023986e6a5824680c8f3a`.
- Final candidate head: `8ea5e941fcbcc0b93e5a4dd180b7a4c15c235930`.
- Mapped home route: `/docs/transformers/main/en/index` → `/voicehub/`.
- Mapped navigation-state route: `/docs/transformers/main/en/installation` → `/voicehub/getting-started/installation/`.

## User-visible change

- Restores the left documentation navigation and right table of contents on all eleven localized homepages.
- Keeps a persistent 270-pixel left navigation and hides the right table of contents at 1024 × 768, without a redundant drawer button.
- Adds filled active navigation styling and visible keyboard focus styling.
- Makes the 242-pixel mobile drawer dismissible by the 133-pixel external backdrop and by Escape; LTR and RTL placement are covered.
- Fixes localized home hero images so they resolve from the shared asset directory instead of locale-local 404 routes.
- Adds a versioned Transformers parity inventory and refreshes release evidence without claiming unfinished parity.

## Files changed

- Localized home sources and shared documentation CSS/JavaScript.
- `mkdocs.yml` navigation and JavaScript loading.
- `docs/project/transformers-parity.md` and release evidence.
- Documentation contracts in `tests/test_documentation_site.py`.

## Rendered evidence

| Viewport | VoiceHub result | Transformers reference |
| --- | --- | --- |
| 1440 × 900 | 242 / 736 / 242-pixel left, content, and right regions inside a 1,220-pixel main region; active and focus styles rendered | Persistent 270-pixel left and right documentation regions |
| 1024 × 768 | 270-pixel left navigation, hidden right TOC, 739-pixel content inside a 1,009-pixel main region | 270-pixel left navigation and hidden right TOC |
| 390 × 844 | Navigation and TOC collapsed; 242-pixel drawer plus 133-pixel backdrop; backdrop and Escape dismissal; LTR and Arabic RTL verified | Navigation and TOC collapsed |

VoiceHub rendered without horizontal overflow in light and dark modes at all three viewports. The reference rendered light and dark at desktop and tablet, and dark at mobile. Screenshots were captured for the checked states; exact measurements and remaining gaps are recorded in the parity inventory.

## Checks executed

- Focused shell regression: `5 passed, 25 deselected, 11 subtests passed`.
- Documentation, release, and AI-guidance suite: `43 passed, 1,143 subtests passed`.
- `mkdocs build --strict --clean`: passed for all eleven languages in 124.57 seconds on the final local evidence files.
- Selected `pre-commit` hooks: passed. The first final run exited nonzero only because YAPF formatted the new asset-path assertion; the formatted rerun passed every hook.
- `python scripts/check_release.py`: passed; version 0.3.0, 68 documented providers, and source/documentation alignment confirmed.
- `git diff --cached --check`: passed.
- Built HTML inspection: all ten translated homes contain two `../assets/voicehub-mark.svg` references and the shared asset exists.
- [Exact-head CI run 30748120965](https://github.com/kadirnar/voicehub/actions/runs/30748120965): all nine Linux, macOS, and Windows Python 3.10-3.12 jobs, both runtime smokes, default runtime, training, and lint passed.
- [Exact-head documentation run 30748120970](https://github.com/kadirnar/voicehub/actions/runs/30748120970): build passed; deploy was skipped as expected for a pull request.
- [Exact-head package run 30748120995](https://github.com/kadirnar/voicehub/actions/runs/30748120995): passed.
- `pre-commit.ci - pr`: passed.

## Remaining gates

- The reference mobile shell does not expose its desktop/tablet theme selector, so its mobile light screenshot remains pending.
- The eight-section top-level navigation hierarchy, header geometry, sticky/scroll-active behavior, and remaining representative page pairs remain open parity gaps.
- Development-server probes requested localized `sitemap.xml` routes that are not emitted per locale; no repository source references those paths, but the warning is recorded rather than counted as a pass.

`uv.lock` remains untracked, unmodified, and unstaged.