### PR TITLE
fix: stabilize documentation tab focus

### DIFF
--- a/docs/javascripts/header-controls.js
+++ b/docs/javascripts/header-controls.js
@@ -358,6 +358,38 @@
   };
 
   const initializeContentTabFocus = () => {
+    const keepLabelInViewport = (label) => {
+      if (!(label instanceof HTMLLabelElement)) return;
+      const labels = label.parentElement;
+      const viewportMargin = 4;
+      let bounds = label.getBoundingClientRect();
+      if (labels instanceof HTMLElement) {
+        if (bounds.left < viewportMargin) {
+          labels.scrollBy({ behavior: "instant", left: bounds.left - viewportMargin });
+        } else if (bounds.right > window.innerWidth - viewportMargin) {
+          labels.scrollBy({
+            behavior: "instant",
+            left: bounds.right - (window.innerWidth - viewportMargin),
+          });
+        }
+      }
+
+      bounds = label.getBoundingClientRect();
+      const header = document.querySelector(".md-header");
+      const headerBottom = header instanceof HTMLElement
+        ? header.getBoundingClientRect().bottom
+        : 0;
+      const viewportTop = Math.max(viewportMargin, headerBottom + viewportMargin);
+      if (bounds.top < viewportTop) {
+        window.scrollBy({ behavior: "instant", top: bounds.top - viewportTop });
+      } else if (bounds.bottom > window.innerHeight - viewportMargin) {
+        window.scrollBy({
+          behavior: "instant",
+          top: bounds.bottom - (window.innerHeight - viewportMargin),
+        });
+      }
+    };
+
     document.querySelectorAll('.tabbed-set > input[type="radio"][id]').forEach((input) => {
       if (!(input instanceof HTMLInputElement) || !(input.parentElement instanceof HTMLElement)) return;
       const label = Array.from(
@@ -366,7 +398,11 @@
       if (!(label instanceof HTMLLabelElement)) return;
 
       input.addEventListener("focus", () => {
-        label.scrollIntoView({ behavior: "instant", block: "nearest", inline: "nearest" });
+        requestAnimationFrame(() => {
+          label.scrollIntoView({ behavior: "instant", block: "nearest", inline: "nearest" });
+          keepLabelInViewport(label);
+          requestAnimationFrame(() => keepLabelInViewport(label));
+        });
         label.classList.add("vh-content-tab--focus");
       });
       input.addEventListener("blur", () => {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -856,6 +856,10 @@ body.vh-search-open {
   outline-offset: 2px;
 }
 
+.md-typeset .tabbed-labels > label {
+  scroll-margin: 0.25rem;
+}
+
 .md-typeset .tabbed-labels > label.vh-content-tab--focus {
   outline: 2px solid var(--vh-indigo);
   outline-offset: 2px;

--- a/scripts/check_documentation_visual.py
+++ b/scripts/check_documentation_visual.py
@@ -3374,22 +3374,47 @@ def _validate_quickstart_tabs(page: Page, case: str) -> None:
             raise DocumentationVisualError(
                 f"{case}: Quickstart tab set {set_index + 1} has an input without an id.")
         inputs.first.focus()
-        for _ in range(target_index):
+        for step_index in range(1, target_index + 1):
             page.keyboard.press("ArrowRight")
+            step_target = inputs.nth(step_index)
+            page.wait_for_function(
+                "input => input.checked && document.activeElement === input",
+                arg=step_target.element_handle(),
+            )
         target_handle = target.element_handle()
         page.wait_for_function(
-            """input => {
-              const label = input.parentElement?.querySelector(
-                `.tabbed-labels > label[for='${input.id}']`
-              );
-              const bounds = label?.getBoundingClientRect();
+            """async input => {
+              const readState = () => {
+                const label = input.parentElement?.querySelector(
+                  `.tabbed-labels > label[for='${input.id}']`
+                );
+                const bounds = label?.getBoundingClientRect();
+                return bounds ? {
+                  bottom: bounds.bottom,
+                  height: bounds.height,
+                  left: bounds.left,
+                  right: bounds.right,
+                  top: bounds.top,
+                  width: bounds.width,
+                } : null;
+              };
+              const before = readState();
+              await new Promise(resolve => requestAnimationFrame(
+                () => requestAnimationFrame(resolve)
+              ));
+              const after = readState();
               const viewportTolerance = 1;
+              const stableTolerance = 0.25;
               return input.checked && document.activeElement === input &&
-                bounds && bounds.width > 0 && bounds.height > 0 &&
-                bounds.left >= -viewportTolerance &&
-                bounds.right <= innerWidth + viewportTolerance &&
-                bounds.top >= -viewportTolerance &&
-                bounds.bottom <= innerHeight + viewportTolerance;
+                before && after && after.width > 0 && after.height > 0 &&
+                Math.abs(after.left - before.left) <= stableTolerance &&
+                Math.abs(after.right - before.right) <= stableTolerance &&
+                Math.abs(after.top - before.top) <= stableTolerance &&
+                Math.abs(after.bottom - before.bottom) <= stableTolerance &&
+                after.left >= -viewportTolerance &&
+                after.right <= innerWidth + viewportTolerance &&
+                after.top >= -viewportTolerance &&
+                after.bottom <= innerHeight + viewportTolerance;
             }""",
             arg=target_handle,
         )

--- a/tests/test_documentation_site.py
+++ b/tests/test_documentation_site.py
@@ -1344,8 +1344,12 @@ print(json.dumps({name: name in sys.modules for name in blocked}))
             "def _validate_quickstart_tabs(",
             1,
         )[1].split("def _validate_quickstart_page_copy", 1)[0]
+        self.assertIn("for step_index in range(1, target_index + 1):", quickstart_tabs)
         self.assertIn('page.keyboard.press("ArrowRight")', quickstart_tabs)
+        self.assertIn("step_target.element_handle()", quickstart_tabs)
         self.assertIn("document.activeElement === input", quickstart_tabs)
+        self.assertIn("requestAnimationFrame", quickstart_tabs)
+        self.assertIn("const stableTolerance = 0.25", quickstart_tabs)
         self.assertIn("const viewportTolerance = 1", quickstart_tabs)
         self.assertNotIn("target.focus()", quickstart_tabs)
 
@@ -1357,6 +1361,7 @@ print(json.dumps({name: name in sys.modules for name in blocked}))
         self.assertIn("_reset_quickstart_tabs(page)", quickstart_interaction)
 
         stylesheet = STYLESHEET_PATH.read_text(encoding="utf-8")
+        self.assertIn("scroll-margin: 0.25rem;", stylesheet)
         for declaration in (
                 "--vh-content-gutter: 24px;",
                 "margin-inline: var(--vh-content-gutter);",
@@ -2088,6 +2093,11 @@ print(json.dumps({name: name in sys.modules for name in blocked}))
             'label.scrollIntoView({ behavior: "instant", block: "nearest", inline: "nearest" })',
             script,
         )
+        self.assertIn("const keepLabelInViewport = (label) =>", script)
+        self.assertIn("const viewportMargin = 4", script)
+        self.assertIn('labels.scrollBy({ behavior: "instant"', script)
+        self.assertIn('window.scrollBy({ behavior: "instant"', script)
+        self.assertIn("requestAnimationFrame(() => keepLabelInViewport(label))", script)
         self.assertIn(
             'region.setAttribute("aria-label", `Scrollable options ${index + 1}`)',
             script,


### PR DESCRIPTION
## Summary

- keep keyboard-focused content-tab labels inside the browser viewport after native focus scrolling settles
- advance Quickstart radio tabs one native ArrowRight step at a time and wait for each selected/focused state
- require stable final label geometry before recording the interaction as passed
- protect the focus behavior and checker contract with documentation source tests

## Failure evidence

The post-merge Documentation workflow on `main` failed twice in run 30886433171. Both attempts passed source tests, the strict build, DOM validation, and Linux screenshot capture, then failed the responsive/keyboard validator. Attempt 2 reported the exact failure as `getting-started/quickstart/index.html / mobile / default / tab set 3: native Tab focused off-canvas element 'tab:Voice activity detection'`. Artifact upload and Pages deployment were skipped.

The failure reproduced locally both as the same off-canvas focus state and as the preceding 30-second target-state timeout. Captured tablet geometry showed a focused tab ending 0.765 CSS pixels below the viewport after the browser's default focus scroll overrode the synchronous correction.

The Transformers Quickstart-to-VoiceHub Quickstart mapping, documentation content, navigation inventory, and approved VoiceHub palette are unchanged by this fix.

Upstream reference retained from the release-candidate comparison: `huggingface/transformers@ff2421c67f35cc83a0fbabbc2633c96734685918`, retrieved 2026-08-04.

## Verification

- `python -m pytest -q tests/test_documentation_site.py -k quickstart` — 2 passed, 3 subtests passed
- focused Quickstart stress matrix — 60/60 cases passed across desktop, tablet, mobile, light, and dark
- `python -m pytest -q tests/test_documentation_site.py` — 64 passed, 1,480 subtests passed
- `mkdocs build --strict --clean --site-dir site` — passed for all 11 locales
- `python scripts/check_documentation_dom.py site` — 10 representative routes and 8 ordered navigation roots passed
- `python scripts/check_documentation_visual.py site` — 60 rendered cases, 60 screenshot cases, 60 accessibility cases, 342 keyboard cases, and 4,587 focus steps passed
- selected pre-commit hooks for all four changed files — passed
- `git diff --check` — passed

No model, registry, optimization, package, checkpoint, dependency, or hardware contract changed.

## Remaining gate

After merge, the `main` Documentation workflow must pass and deploy the Pages artifact. The public site remains on the August 2 build until that deployment completes.
