### PR TITLE
fix: make documentation tab focus deterministic

### DIFF
--- a/docs/javascripts/header-controls.js
+++ b/docs/javascripts/header-controls.js
@@ -390,23 +390,52 @@
       }
     };
 
-    document.querySelectorAll('.tabbed-set > input[type="radio"][id]').forEach((input) => {
-      if (!(input instanceof HTMLInputElement) || !(input.parentElement instanceof HTMLElement)) return;
-      const label = Array.from(
-        input.parentElement.querySelectorAll(".tabbed-labels > label[for]"),
-      ).find((candidate) => candidate instanceof HTMLLabelElement && candidate.htmlFor === input.id);
+    const revealLabel = (label) => {
       if (!(label instanceof HTMLLabelElement)) return;
-
-      input.addEventListener("focus", () => {
-        requestAnimationFrame(() => {
-          label.scrollIntoView({ behavior: "instant", block: "nearest", inline: "nearest" });
-          keepLabelInViewport(label);
-          requestAnimationFrame(() => keepLabelInViewport(label));
-        });
-        label.classList.add("vh-content-tab--focus");
+      requestAnimationFrame(() => {
+        label.scrollIntoView({ behavior: "instant", block: "nearest", inline: "nearest" });
+        keepLabelInViewport(label);
+        requestAnimationFrame(() => keepLabelInViewport(label));
       });
-      input.addEventListener("blur", () => {
-        label.classList.remove("vh-content-tab--focus");
+    };
+
+    document.querySelectorAll(".tabbed-set").forEach((tabSet) => {
+      if (!(tabSet instanceof HTMLElement)) return;
+      const inputs = Array.from(
+        tabSet.querySelectorAll(':scope > input[type="radio"][id]:not(:disabled)'),
+      ).filter((input) => input instanceof HTMLInputElement);
+      if (!inputs.length) return;
+
+      inputs.forEach((input) => {
+        const label = Array.from(
+          tabSet.querySelectorAll(".tabbed-labels > label[for]"),
+        ).find((candidate) => candidate instanceof HTMLLabelElement && candidate.htmlFor === input.id);
+        if (!(label instanceof HTMLLabelElement)) return;
+
+        input.addEventListener("focus", () => {
+          revealLabel(label);
+          label.classList.add("vh-content-tab--focus");
+        });
+        input.addEventListener("blur", () => {
+          label.classList.remove("vh-content-tab--focus");
+        });
+      });
+
+      tabSet.addEventListener("keydown", (event) => {
+        if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+        if (!(event.target instanceof HTMLInputElement) || !inputs.includes(event.target)) return;
+        const direction = event.key === "ArrowRight" || event.key === "ArrowDown"
+          ? 1
+          : event.key === "ArrowLeft" || event.key === "ArrowUp" ? -1 : 0;
+        if (!direction) return;
+
+        event.preventDefault();
+        const currentIndex = inputs.indexOf(event.target);
+        const nextInput = inputs[(currentIndex + direction + inputs.length) % inputs.length];
+        nextInput.focus({ preventScroll: true });
+        nextInput.checked = true;
+        nextInput.dispatchEvent(new Event("input", { bubbles: true }));
+        nextInput.dispatchEvent(new Event("change", { bubbles: true }));
       });
     });
   };

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -857,7 +857,7 @@ body.vh-search-open {
 }
 
 .md-typeset .tabbed-labels > label {
-  scroll-margin: 0.25rem;
+  scroll-margin: 1rem;
 }
 
 .md-typeset .tabbed-labels > label.vh-content-tab--focus {

--- a/scripts/check_documentation_visual.py
+++ b/scripts/check_documentation_visual.py
@@ -3373,9 +3373,19 @@ def _validate_quickstart_tabs(page: Page, case: str) -> None:
         if not target_id:
             raise DocumentationVisualError(
                 f"{case}: Quickstart tab set {set_index + 1} has an input without an id.")
-        inputs.first.focus()
+        inputs.first.evaluate("input => input.focus({preventScroll: true})")
         for step_index in range(1, target_index + 1):
+            step_source = inputs.nth(step_index - 1)
+            step_source.evaluate(
+                """input => input.ownerDocument.addEventListener("keydown", event => {
+                  input.dataset.vhArrowDefaultPrevented = String(event.defaultPrevented);
+                }, {once: true})""")
             page.keyboard.press("ArrowRight")
+            step_source_handle = step_source.element_handle()
+            page.wait_for_function(
+                "input => input.dataset.vhArrowDefaultPrevented === 'true'",
+                arg=step_source_handle,
+            )
             step_target = inputs.nth(step_index)
             page.wait_for_function(
                 "input => input.checked && document.activeElement === input",

--- a/tests/test_documentation_site.py
+++ b/tests/test_documentation_site.py
@@ -1345,7 +1345,11 @@ print(json.dumps({name: name in sys.modules for name in blocked}))
             1,
         )[1].split("def _validate_quickstart_page_copy", 1)[0]
         self.assertIn("for step_index in range(1, target_index + 1):", quickstart_tabs)
+        self.assertIn('inputs.first.evaluate("input => input.focus({preventScroll: true})")', quickstart_tabs)
+        self.assertIn("step_source.element_handle()", quickstart_tabs)
+        self.assertIn('input.ownerDocument.addEventListener("keydown"', quickstart_tabs)
         self.assertIn('page.keyboard.press("ArrowRight")', quickstart_tabs)
+        self.assertIn("input.dataset.vhArrowDefaultPrevented === 'true'", quickstart_tabs)
         self.assertIn("step_target.element_handle()", quickstart_tabs)
         self.assertIn("document.activeElement === input", quickstart_tabs)
         self.assertIn("requestAnimationFrame", quickstart_tabs)
@@ -1361,7 +1365,7 @@ print(json.dumps({name: name in sys.modules for name in blocked}))
         self.assertIn("_reset_quickstart_tabs(page)", quickstart_interaction)
 
         stylesheet = STYLESHEET_PATH.read_text(encoding="utf-8")
-        self.assertIn("scroll-margin: 0.25rem;", stylesheet)
+        self.assertIn("scroll-margin: 1rem;", stylesheet)
         for declaration in (
                 "--vh-content-gutter: 24px;",
                 "margin-inline: var(--vh-content-gutter);",
@@ -2098,6 +2102,11 @@ print(json.dumps({name: name in sys.modules for name in blocked}))
         self.assertIn('labels.scrollBy({ behavior: "instant"', script)
         self.assertIn('window.scrollBy({ behavior: "instant"', script)
         self.assertIn("requestAnimationFrame(() => keepLabelInViewport(label))", script)
+        self.assertIn('tabSet.addEventListener("keydown", (event) => {', script)
+        self.assertIn("event.preventDefault();", script)
+        self.assertIn("nextInput.focus({ preventScroll: true });", script)
+        self.assertIn('nextInput.dispatchEvent(new Event("input", { bubbles: true }))', script)
+        self.assertIn('nextInput.dispatchEvent(new Event("change", { bubbles: true }))', script)
         self.assertIn(
             'region.setAttribute("aria-label", `Scrollable options ${index + 1}`)',
             script,


### PR DESCRIPTION
## Transformers reference

- Current upstream reference: `huggingface/transformers@49140dd12fb43759e5179cc2457c073579d163bb`.
- Mapped interaction: Quickstart content tabs must preserve familiar horizontal radio-tab keyboard behavior while keeping the visible tab label in the viewport.

## Failure evidence

- Main documentation run [30914575721](https://github.com/kadirnar/voicehub/actions/runs/30914575721) failed after PR #74 merged because Chromium moved the focused Quickstart tab label just outside the desktop viewport after the earlier two-frame correction had passed.
- The exact main behavior reproduced locally: a 100-iteration desktop/default stress run failed at iteration 28 on tab set 2, and subsequent probes failed within 1-7 iterations. These failed runs are not counted as passes.

## User-visible change

- Content-tab ArrowLeft, ArrowRight, ArrowUp, and ArrowDown navigation now selects and focuses the adjacent tab with `preventScroll`, dispatches the normal input/change events, and performs the existing visible-label correction without allowing a competing native radio scroll.
- Tab labels use a 1rem scroll margin so small late fractional layout shifts cannot leave the focus outline clipped at a viewport edge.
- The rendered validator now proves that each exercised ArrowRight event used the deterministic handler and starts the Arrow test without introducing a separate synthetic focus scroll.

## Files changed

- `docs/javascripts/header-controls.js`
- `docs/stylesheets/extra.css`
- `scripts/check_documentation_visual.py`
- `tests/test_documentation_site.py`

## Executed checks

- Focused source regression: 2 passed, 3 subtests passed.
- Post-fix desktop/default stress: 100/100 passed.
- Post-fix cross-viewport/palette stress: 60/60 passed across desktop, tablet, mobile, default, and slate.
- Complete documentation source suite: 64 passed, 1,480 subtests passed.
- Strict clean eleven-language documentation build: passed.
- Rendered DOM/navigation validator: 10 representative routes and the exact eight top-level navigation roots passed.
- JavaScript syntax check: passed.
- Full rendered validator: 60 visual cases, 60 Axe 4.12.1 accessibility cases, 342 keyboard cases, and 4,580 sequential focus steps across 10 routes, 3 viewports, and 2 palettes passed.
- Selected pre-commit pipeline over all four changed files: every applicable hook passed.
- `git diff --check`: passed.

## Remaining gates

- Exact-head pull-request CI is pending and is not counted as passed.
- GitHub Pages upload and deployment run only after merge to `main`; live-site verification therefore remains pending.
