### PR TITLE
Remove root guidance pointers and deploy PR docs

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -10,9 +10,9 @@ Repository guidance has one canonical owner per concern:
 - `.ai/review-rules.md` defines first-pass pull-request review rules.
 - `.ai/skills/` contains task-specific quality workflows.
 
-Read `.ai/GOAL.md` and `.ai/LOOP.md` completely before planning or editing. Root
-`AGENTS.md`, `GOAL.md`, `LOOP.md`, and `CLAUDE.md` are compatibility symlinks;
-never copy canonical guidance into them or edit them as separate sources.
+Read `.ai/GOAL.md` and `.ai/LOOP.md` completely before planning or editing.
+Canonical guidance exists only under `.ai/`; do not add root-level copies,
+pointers, or compatibility symlinks.
 
 Write user-facing explanations and final reports in English. Keep source code,
 identifiers, comments, docstrings, configuration, commit messages, pull-request

--- a/.ai/GOAL.md
+++ b/.ai/GOAL.md
@@ -35,9 +35,9 @@ integration.
 
 Repository guidance must follow the Transformers `.ai/` convention. Canonical
 agent instructions, the product goal, the iteration loop, review rules, and
-task-specific skills live under `.ai/`. Root-level compatibility symlinks keep
-the guidance discoverable by hosted and local coding agents without creating
-duplicate sources of truth.
+task-specific skills live under `.ai/`. Root-level guidance copies, pointers,
+and compatibility symlinks are intentionally absent so `.ai/` remains the only
+discoverable source of truth.
 
 Skills must be concise, validated, and limited to fragile or repetitive quality
 workflows. They must strengthen the same product contract rather than introduce
@@ -154,8 +154,8 @@ and the modern color tokens may differ.
    traceable to reproducible tests, visual evidence, benchmarks, or official
    upstream sources.
 1. The canonical `.ai/` guidance, review rules, and task skills validate
-   successfully; root compatibility symlinks resolve to the canonical files and
-   no duplicate instruction source can drift independently.
+   successfully; no root-level guidance copy, pointer, or compatibility symlink
+   exists and no duplicate instruction source can drift independently.
 
 ## Constraints
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -185,3 +185,5 @@ jobs:
       - name: Deploy GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        with:
+          timeout: 1200000

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,7 +59,10 @@ jobs:
           retention-days: 1
 
       - name: Upload GitHub Pages artifact
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        if: >-
+          (github.event_name != 'pull_request' && github.ref == 'refs/heads/main') ||
+          (github.event_name == 'pull_request' &&
+           github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
@@ -159,7 +162,10 @@ jobs:
 
   deploy:
     name: Deploy documentation
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    if: >-
+      (github.event_name != 'pull_request' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     needs: [build, screenshots, visual]
     runs-on: ubuntu-latest
     concurrency:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -185,5 +185,3 @@ jobs:
       - name: Deploy GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
-        with:
-          timeout: 1200000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,0 @@
-.ai/AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-.ai/AGENTS.md

--- a/GOAL.md
+++ b/GOAL.md
@@ -1,1 +1,0 @@
-.ai/GOAL.md

--- a/LOOP.md
+++ b/LOOP.md
@@ -1,1 +1,0 @@
-.ai/LOOP.md

--- a/tests/test_ai_guidance.py
+++ b/tests/test_ai_guidance.py
@@ -9,12 +9,7 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 AI_ROOT = PROJECT_ROOT / ".ai"
-CANONICAL_GUIDANCE = {
-    "AGENTS.md": ".ai/AGENTS.md",
-    "GOAL.md": ".ai/GOAL.md",
-    "LOOP.md": ".ai/LOOP.md",
-    "CLAUDE.md": ".ai/AGENTS.md",
-}
+ROOT_GUIDANCE_NAMES = ("AGENTS.md", "GOAL.md", "LOOP.md", "CLAUDE.md")
 REQUIRED_AI_FILES = (
     AI_ROOT / "AGENTS.md",
     AI_ROOT / "GOAL.md",
@@ -22,11 +17,6 @@ REQUIRED_AI_FILES = (
     AI_ROOT / "review-rules.md",
 )
 FRONTMATTER_PATTERN = re.compile(r"\A---\n(?P<body>.*?)\n---\n", re.DOTALL)
-
-
-def normalize_pointer_target(target: str) -> str:
-    """Return a repository-relative pointer with portable separators."""
-    return target.replace("\\", "/")
 
 
 class AIGuidanceContractTests(unittest.TestCase):
@@ -38,20 +28,14 @@ class AIGuidanceContractTests(unittest.TestCase):
                 self.assertTrue(
                     filepath.read_text(encoding="utf-8").strip(), f"Empty AI guidance: {filepath}")
 
-    def test_root_guidance_points_to_canonical_files(self) -> None:
-        for root_name, expected_target in CANONICAL_GUIDANCE.items():
+    def test_root_guidance_is_absent(self) -> None:
+        for root_name in ROOT_GUIDANCE_NAMES:
             root_path = PROJECT_ROOT / root_name
             with self.subTest(root_name=root_name):
-                self.assertTrue(root_path.exists(), f"Missing root compatibility file: {root_name}")
-                if root_path.is_symlink():
-                    actual_target = os.readlink(root_path)
-                else:
-                    # Git may materialize a symlink as a text pointer on Windows.
-                    actual_target = root_path.read_text(encoding="utf-8").strip()
-                self.assertEqual(normalize_pointer_target(actual_target), expected_target)
-
-    def test_windows_style_pointer_targets_are_portable(self) -> None:
-        self.assertEqual(normalize_pointer_target(r".ai\AGENTS.md"), ".ai/AGENTS.md")
+                self.assertFalse(
+                    os.path.lexists(root_path),
+                    f"Root guidance must not duplicate or point to .ai/: {root_name}",
+                )
 
     def test_guidance_concerns_have_one_canonical_owner(self) -> None:
         canonical_text = {

--- a/tests/test_documentation_site.py
+++ b/tests/test_documentation_site.py
@@ -2239,7 +2239,6 @@ print(json.dumps({name: name in sys.modules for name in blocked}))
             "if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'",
             docs_workflow,
         )
-        self.assertEqual(docs_workflow.count("timeout: 1200000"), 1)
 
         release_workflow = (REPOSITORY_ROOT / ".github" / "workflows" /
                             "release.yml").read_text(encoding="utf-8")

--- a/tests/test_documentation_site.py
+++ b/tests/test_documentation_site.py
@@ -2239,6 +2239,7 @@ print(json.dumps({name: name in sys.modules for name in blocked}))
             "if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'",
             docs_workflow,
         )
+        self.assertEqual(docs_workflow.count("timeout: 1200000"), 1)
 
         release_workflow = (REPOSITORY_ROOT / ".github" / "workflows" /
                             "release.yml").read_text(encoding="utf-8")

--- a/tests/test_documentation_site.py
+++ b/tests/test_documentation_site.py
@@ -2231,6 +2231,14 @@ print(json.dumps({name: name in sys.modules for name in blocked}))
         self.assertIn('--viewport "${{ matrix.viewport }}"', docs_workflow)
         self.assertIn('--palette "${{ matrix.palette }}"', docs_workflow)
         self.assertIn("needs: [build, screenshots, visual]", docs_workflow)
+        self.assertEqual(
+            docs_workflow.count("github.event.pull_request.head.repo.full_name == github.repository"),
+            2,
+        )
+        self.assertNotIn(
+            "if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'",
+            docs_workflow,
+        )
 
         release_workflow = (REPOSITORY_ROOT / ".github" / "workflows" /
                             "release.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- delete root `AGENTS.md`, `CLAUDE.md`, `GOAL.md`, and `LOOP.md` symlinks so canonical guidance exists only under `.ai/`
- replace the compatibility-pointer test with a fail-closed contract that rejects any future root copy, pointer, or symlink
- upload and deploy the Pages artifact after all documentation jobs pass on same-repository pull requests
- keep fork pull requests validation-only because GitHub gives them read-only tokens
- allow `refs/pull/*/merge` in the `github-pages` environment while retaining the existing `main` policy

## Deployment contract

The Pages job still needs `[build, screenshots, visual]`, so deployment cannot start until the strict build, DOM validation, screenshot capture, and all six viewport/palette visual shards pass. The same-repository check prevents fork PR code from receiving Pages write access.

GitHub reference:

- https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages
- https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax

## Checks

- `uv run --no-sync python -m pytest -q tests/test_ai_guidance.py tests/test_documentation_site.py` — 73 passed, 1,597 subtests passed
- selected `pre-commit` hooks — passed
- workflow YAML parsing — passed
- `git diff --check HEAD` — passed
- PR run `31107926303`: build, screenshot capture, all six visual shards, package CI, lint, training, and the full OS/Python matrix passed
- PR run `31107926303`, failed-job rerun: `Deploy documentation` passed in 11 seconds without a new commit
- live `https://kadirnar.github.io/voicehub/` index SHA-256 matches the PR `github-pages` artifact exactly: `bd6eb70b49d72874a0130ca91da0f07fa6e6fc9dd45f029c5c9cf647b615d2c0`

## Live deployment evidence

The repository-side PR deployment path is enabled and verified end to end: the Pages artifact uploads, the protected `github-pages` environment accepts `refs/pull/*/merge`, deployment starts only after the documentation gates, and the PR artifact is live before merge.

The first live verification attempt encountered the GitHub Pages queue incident reported by multiple repositories on 2026-08-06 and exceeded the official action limit. GitHub completed publication afterward, and rerunning only the failed job reconciled the stale check in 11 seconds without changing the commit:

- https://github.com/actions/deploy-pages/issues/406

The failing and last successful VoiceHub artifacts both contain 2,484 files and are 152 MB uncompressed, confirming there was no artifact-size or file-count regression.

## External configuration

The `github-pages` environment now permits `main` and `refs/pull/*/merge`. No release or package publication is included.
