### PR TITLE
docs: add descriptive VoiceHub heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
-# VoiceHub: A Unified Python Toolkit for Speech and Audio AI
+<h2 align="center">VoiceHub: A Unified Python Toolkit for Speech and Audio AI</h2>
 
 <div align="center">
   <img width="100%" alt="Abstract sound waves representing VoiceHub's unified speech toolkit" src="https://raw.githubusercontent.com/kadirnar/voicehub/main/assets/readme-hero.png">
-  <p>One Python interface for text-to-speech, speech recognition, and voice activity detection.</p>
 </div>
-
-Lazy model loading, normalized outputs, shared optimization controls, and
-training support—without downloading a model until you select one.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <div align="center">
   <img width="100%" alt="Abstract sound waves representing VoiceHub's unified speech toolkit" src="https://raw.githubusercontent.com/kadirnar/voicehub/main/assets/readme-hero.png">
+  <p>VoiceHub: <strong>Unified Inference, Training, and Optimization for TTS, ASR, and VAD</strong></p>
   <p>One Python interface for text-to-speech, speech recognition, and voice activity detection.</p>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
+# VoiceHub: A Unified Python Toolkit for Speech and Audio AI
+
 <div align="center">
   <img width="100%" alt="Abstract sound waves representing VoiceHub's unified speech toolkit" src="https://raw.githubusercontent.com/kadirnar/voicehub/main/assets/readme-hero.png">
-  <p>VoiceHub: <strong>Unified Inference, Training, and Optimization for TTS, ASR, and VAD</strong></p>
   <p>One Python interface for text-to-speech, speech recognition, and voice activity detection.</p>
 </div>
 


### PR DESCRIPTION
## Summary

- Displays VoiceHub: A Unified Python Toolkit for Speech and Audio AI as a smaller centered heading above the README hero.
- Removes the two legacy description lines below the heading and hero.
- Keeps the hero image and logo unchanged.

## Testing

- uv run --no-sync python -m pytest -q tests/test_documentation_site.py
- 69 passed, 1583 subtests passed