### PR TITLE
Fix documentation formatter CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,4 +67,4 @@ repos:
     rev: v1.7.8
     hooks:
       - id: docformatter
-        exclude: '^(?:scripts/(?:generate_model_(?:notebooks|pages)|scaffold_model)|tests/test_model_scaffold)\.py$'
+        exclude: '^(?:scripts/(?:documentation_references|generate_(?:model_(?:notebooks|pages)|optimization_pages)|scaffold_model)|tests/test_model_scaffold)\.py$'

--- a/scripts/documentation_references.py
+++ b/scripts/documentation_references.py
@@ -59,6 +59,9 @@ PYANNOTE_PAPER = _paper("pyannote.audio: neural building blocks for speaker diar
 SPEECHBRAIN_PAPER = _paper("SpeechBrain: A General-Purpose Speech Toolkit", "2106.04624")
 FUNASR_PAPER = _paper("FunASR: A Fundamental End-to-End Speech Recognition Toolkit", "2305.11013")
 
+# Keep the URL-heavy declarative catalog stable and readable. Automated YAPF
+# wrapping makes these records harder to review and can produce Flake8 E251.
+# yapf: disable
 
 MODEL_REFERENCES = {
     # Text to speech.
@@ -386,7 +389,7 @@ cmake --build build --target audiocpp_cli -j 8''',
         related_guide="../guides/optional-backends.md",
     ),
 )
-
+# yapf: enable
 
 __all__ = [
     "MODEL_REFERENCES",

--- a/scripts/generate_optimization_pages.py
+++ b/scripts/generate_optimization_pages.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(REPOSITORY_ROOT))
 sys.path.insert(0, str(SCRIPTS_ROOT))
 
 from documentation_references import OPTIMIZATION_GUIDES, OptimizationGuide, Reference  # noqa: E402
+
 from voicehub.optimization import OPTIMIZATION_PASSES  # noqa: E402
 
 PAGE_DIR = REPOSITORY_ROOT / "docs" / "optimizations"
@@ -51,8 +52,7 @@ def render_page(guide: OptimizationGuide) -> str:
         "No dedicated upstream research paper is published for this integration.")
     github = _reference_links(guide.github)
     implementation = (
-        _implementation_link(guide.implementation)
-        if guide.implementation is not None else
+        _implementation_link(guide.implementation) if guide.implementation is not None else
         "No VoiceHub pass implementation; use the external source project directly.")
     return f'''---
 description: Usage, support boundaries, paper, and source links for {guide.title}.
@@ -134,8 +134,8 @@ def render_navigation(guides: tuple[OptimizationGuide, ...]) -> str:
     for group in tuple(dict.fromkeys(guide.group for guide in guides)):
         lines.append(f"      - {group}:")
         lines.extend(
-            f'          - "{guide.title}": optimizations/{guide.slug}.md'
-            for guide in guides if guide.group == group)
+            f'          - "{guide.title}": optimizations/{guide.slug}.md' for guide in guides
+            if guide.group == group)
     lines.append(NAVIGATION_END)
     return "\n".join(lines)
 
@@ -144,8 +144,7 @@ def render_site_config(guides: tuple[OptimizationGuide, ...]) -> str:
     """Replace the generated optimization navigation block."""
     source = SITE_CONFIG_PATH.read_text(encoding="utf-8")
     if source.count(NAVIGATION_START) != 1 or source.count(NAVIGATION_END) != 1:
-        raise RuntimeError(
-            "mkdocs.yml must contain exactly one generated optimization navigation block")
+        raise RuntimeError("mkdocs.yml must contain exactly one generated optimization navigation block")
     prefix, remainder = source.split(NAVIGATION_START, 1)
     _, suffix = remainder.split(NAVIGATION_END, 1)
     return f"{prefix}{render_navigation(guides)}{suffix}"
@@ -160,8 +159,7 @@ def _validate_contract(guides: tuple[OptimizationGuide, ...]) -> None:
     if documented != registered:
         missing = sorted(registered - documented)
         unknown = sorted(documented - registered)
-        raise RuntimeError(
-            f"Optimization reference coverage mismatch: missing={missing}, unknown={unknown}")
+        raise RuntimeError(f"Optimization reference coverage mismatch: missing={missing}, unknown={unknown}")
     for guide in guides:
         if not guide.github:
             raise RuntimeError(f"{guide.slug} must link at least one upstream GitHub repository")


### PR DESCRIPTION
## Summary

- apply the repository isort and YAPF output to the optimization generator
- keep the declarative reference catalogs stable under YAPF
- exclude generator/reference data files from docformatter to prevent formatter churn

## Validation

- pre-commit run --all-files
- 93 documentation/scaffold tests passed
- 1,681 subtests passed
- model and optimization generators are current