### PR TITLE
test: keep docs checks dependency-free

### DIFF
--- a/tests/test_documentation_site.py
+++ b/tests/test_documentation_site.py
@@ -384,11 +384,14 @@ class DocumentationSiteTests(unittest.TestCase):
         )
         self.assertIn("speech-to-text subset", documented_parameters["asr_seamless_m4t_v2"].note)
         from voicehub.architectures.medasr.configuration import MedASRConfig
-        from voicehub.architectures.medasr.modeling import MedASRForCTC
-        medasr_model = MedASRForCTC(MedASRConfig(), initialize=False)
+        medasr_config = MedASRConfig()
+        medasr_metadata = runpy.run_path(
+            str(REPOSITORY_ROOT / "voicehub" / "architectures" / "medasr" / "metadata.py"))
+        medasr_checkpoint = medasr_metadata["MEDASR_CHECKPOINT"]
+        batch_norm_buffers = medasr_config.num_hidden_layers * (2 * medasr_config.hidden_size + 1)
         self.assertEqual(
             documented_parameters["asr_medasr"].count,
-            sum(parameter.numel() for parameter in medasr_model.parameters()),
+            medasr_checkpoint["parameters"] - batch_norm_buffers,
         )
         self.assertIn("BatchNorm buffers are excluded", documented_parameters["asr_medasr"].note)
         melotts_spec = next(spec for spec in specs if spec.model_type == "melotts")


### PR DESCRIPTION
## Summary

- avoid importing the PyTorch MedASR model in documentation tests
- validate the parameter count from lightweight configuration and audited metadata

## Tests

- `python -m pytest tests/test_documentation_site.py -q`
- all 74 documentation tests with `torch` imports explicitly blocked
- pre-commit checks for the changed file